### PR TITLE
feat: workspace theme support + bug fixes

### DIFF
--- a/components/polylith/bricks/component.py
+++ b/components/polylith/bricks/component.py
@@ -1,4 +1,3 @@
-from collections.abc import Generator
 from pathlib import Path
 
 from polylith.bricks.brick import create_brick
@@ -11,10 +10,13 @@ def create_component(path: Path, namespace: str, package: str) -> None:
     create_test(path, components_dir, namespace, package)
 
 
-def get_component_dirs(path: Path, top_dir, ns) -> Generator:
+def get_component_dirs(path: Path, top_dir, ns) -> list:
     component_dir = path / top_dir / ns
 
-    return (f for f in component_dir.iterdir() if f.is_dir())
+    if not component_dir.exists():
+        return []
+
+    return [f for f in component_dir.iterdir() if f.is_dir()]
 
 
 def get_components_data(

--- a/components/polylith/info/report.py
+++ b/components/polylith/info/report.py
@@ -24,6 +24,9 @@ def brick_status(brick, bricks) -> str:
 def print_bricks_in_projects(
     projects_data: list[dict], bases_data: list[dict], components_data: list[dict]
 ) -> None:
+    if not components_data and not bases_data:
+        return
+
     console = Console(theme=info_theme)
     table = Table(box=box.SIMPLE_HEAD)
     table.add_column("[data]brick[/]")
@@ -53,6 +56,10 @@ def print_workspace_summary(
 
     console.print(Padding("[data]Workspace summary[/]", (1, 0, 1, 0)))
 
-    console.print(f"[proj]projects[/]: [data]{len(projects_data)}[/]")
-    console.print(f"[comp]components[/]: [data]{len(components_data)}[/]")
-    console.print(f"[base]bases[/]: [data]{len(bases_data)}[/]")
+    number_of_projects = len(projects_data) if projects_data else 0
+    number_of_components = len(components_data) if components_data else 0
+    number_of_bases = len(bases_data) if bases_data else 0
+
+    console.print(f"[proj]projects[/]: [data]{number_of_projects}[/]")
+    console.print(f"[comp]components[/]: [data]{number_of_components}[/]")
+    console.print(f"[base]bases[/]: [data]{number_of_bases}[/]")

--- a/components/polylith/poetry/commands/create_workspace.py
+++ b/components/polylith/poetry/commands/create_workspace.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 from cleo.helpers import option
-
 from poetry.console.commands.command import Command
 from polylith.workspace.create import create_workspace
 
@@ -11,18 +10,25 @@ class CreateWorkspaceCommand(Command):
     description = "Creates a <comment>Polylith</> workspace in the current directory."
 
     options = [
-        option("name", None, "Name of the workspace.", flag=False),
+        option(long_name="name", description="Name of the workspace.", flag=False),
+        option(
+            long_name="theme",
+            description="Workspace theme",
+            flag=False,
+            default="tdd",
+        ),
     ]
 
     def handle(self) -> int:
         path = Path.cwd()
         namespace = self.option("name")
+        theme = self.option("theme")
 
         if not namespace:
             raise ValueError(
                 "Please add a workspace name. Poetry poly create workspace --name myname"
             )
 
-        create_workspace(path, namespace)
+        create_workspace(path, namespace, theme)
 
         return 0

--- a/components/polylith/readme/readme.py
+++ b/components/polylith/readme/readme.py
@@ -5,8 +5,6 @@ from polylith import log, repo
 
 template = """\
 # A Python Polylith repo
-The top namespace is `{namespace}`.
-
 
 ## Docs
 The official Polylith documentation:

--- a/components/polylith/test/tests.py
+++ b/components/polylith/test/tests.py
@@ -4,6 +4,14 @@ from polylith.dirs import create_dir
 from polylith.files import create_file
 from polylith.workspace import parser
 
+template = """\
+from {namespace}.{package} import {modulename}
+
+
+def test_sample():
+    assert {modulename} is not None
+"""
+
 
 def create_test(
     root: Path, brick: str, namespace: str, package: str, modulename: str = "core"
@@ -18,7 +26,6 @@ def create_test(
     create_file(d, "__init__.py")
     test_file = create_file(d, f"test_{modulename}.py")
 
-    template = parser.get_test_template_from_config(root)
     content = template.format(
         namespace=namespace, package=package, modulename=modulename
     )

--- a/components/polylith/workspace/create.py
+++ b/components/polylith/workspace/create.py
@@ -11,25 +11,16 @@ namespace = "{namespace}"
 git_tag_pattern = "stable-*"
 
 [tool.polylith.structure]
-bricks = "{brick}/{namespace}/{package}"
-tests = "test/{brick}/{namespace}/{package}"
+theme = "{theme}"
 
 [tool.polylith.test]
 enabled = true
-template = \"\"\"\
-from {namespace}.{package} import {modulename}
-
-
-def test_sample():
-    assert {modulename} is not None
-\"\"\"
 """
 
 
-def create_workspace_config(path: Path, namespace: str) -> None:
-    content: dict = tomlkit.loads(
-        template.replace('namespace = "{namespace}"', f'namespace = "{namespace}"')
-    )
+def create_workspace_config(path: Path, namespace: str, theme: str) -> None:
+    formatted = template.format(namespace=namespace, theme=theme)
+    content: dict = tomlkit.loads(formatted)
 
     fullpath = path / repo.workspace_file
 
@@ -37,13 +28,13 @@ def create_workspace_config(path: Path, namespace: str) -> None:
         f.write(tomlkit.dumps(content))
 
 
-def create_workspace(path: Path, namespace: str) -> None:
+def create_workspace(path: Path, namespace: str, theme: str) -> None:
     create_dir(path, repo.bases_dir, keep=True)
     create_dir(path, repo.components_dir, keep=True)
     create_dir(path, repo.projects_dir, keep=True)
 
     create_development(path, keep=True)
 
-    create_workspace_config(path, namespace)
+    create_workspace_config(path, namespace, theme)
 
     readme.create_workspace_readme(path, namespace)

--- a/components/polylith/workspace/parser.py
+++ b/components/polylith/workspace/parser.py
@@ -24,18 +24,6 @@ def get_git_tag_pattern_from_config(path: Path) -> str:
     return toml["tool"]["polylith"]["git_tag_pattern"]
 
 
-def get_brick_structure_from_config(path: Path) -> str:
-    toml: dict = _load_workspace_config(path)
-
-    return toml["tool"]["polylith"]["structure"]["bricks"]
-
-
-def get_test_template_from_config(path: Path) -> str:
-    toml: dict = _load_workspace_config(path)
-
-    return toml["tool"]["polylith"]["test"]["template"]
-
-
 def is_test_generation_enabled(path: Path) -> bool:
     toml: dict = _load_workspace_config(path)
 
@@ -43,7 +31,25 @@ def is_test_generation_enabled(path: Path) -> bool:
     return bool(enabled)
 
 
-def get_tests_structure_from_config(path: Path) -> str:
+def get_theme_from_config(path: Path) -> str:
     toml: dict = _load_workspace_config(path)
 
-    return toml["tool"]["polylith"]["structure"]["tests"]
+    return toml["tool"]["polylith"]["structure"]["theme"] or "tdd"
+
+
+def get_brick_structure_from_config(path: Path) -> str:
+    theme = get_theme_from_config(path)
+
+    if theme == "loose":
+        return "{brick}/{namespace}/{package}"
+
+    return "{brick}/{package}/src/{namespace}/{package}"
+
+
+def get_tests_structure_from_config(path: Path) -> str:
+    theme = get_theme_from_config(path)
+
+    if theme == "loose":
+        return "test/{brick}/{namespace}/{package}"
+
+    return "{brick}/{package}/test/{namespace}/{package}"

--- a/development/david.py
+++ b/development/david.py
@@ -35,3 +35,5 @@ if tag:
 
 info.get_bricks_in_projects(root)
 
+ns = workspace.parser.get_namespace_from_config(root)
+bases_data = bricks.base.get_bases_data(root, ns)

--- a/workspace.toml
+++ b/workspace.toml
@@ -3,15 +3,7 @@ namespace = "polylith"
 git_tag_pattern = "v*"
 
 [tool.polylith.structure]
-bricks = "{brick}/{namespace}/{package}"
-tests = "test/{brick}/{namespace}/{package}"
+theme = "loose"
 
 [tool.polylith.test]
 enabled = false
-template = """\
-from {namespace}.{package} import {modulename}
-
-
-def test_sample():
-    assert {modulename} is not None
-"""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add support for different workspace themes: tdd or loose. 

## Description
<!--- Describe your changes in detail -->
The `poetry poly create workspace` command now supports a `--theme` property.

(`tdd` is the default if no theme is set)

__tdd__ 
Create bricks according to the original Polylith implementation, such as:
`components/<package>/src/<namespace>/<package>` and `components/<package>/test/<namespace>/<package>`

__loose__
Create bricks in a (maybe) python style, such as:
`components/<namespace>/<package>` and `test/<namespace>/<package>`