### PR TITLE
fix: unpack sets with python 3.8-syntax

### DIFF
--- a/components/polylith/diff/report.py
+++ b/components/polylith/diff/report.py
@@ -90,8 +90,9 @@ def print_short_diff(
 
     a = _changed_projects(projects_data, "components", components)
     b = _changed_projects(projects_data, "bases", bases)
+    c = set(projects)
 
-    res = a | b | set(projects)
+    res = {*a, *b, *c}
 
     console = Console(theme=info_theme)
     console.print(",".join(res))

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.0.5"
+version = "1.0.6"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://github.com/davidvujic/python-polylith"


### PR DESCRIPTION
Bug fix: merging with the pipe char won't work for Python 3.8.