### PR TITLE
fix: create-command with name as path

### DIFF
--- a/components/polylith/interface/interfaces.py
+++ b/components/polylith/interface/interfaces.py
@@ -9,11 +9,19 @@ __all__ = ["{modulename}"]
 """
 
 
+def to_namespaced_path(package: str) -> str:
+    parts = package.split("/")
+
+    return ".".join(parts)
+
+
 def create_interface(path: Path, namespace: str, package: str, modulename: str) -> None:
     interface = create_file(path, "__init__.py")
 
+    package_path = to_namespaced_path(package)
+
     content = template.format(
-        namespace=namespace, package=package, modulename=modulename
+        namespace=namespace, package=package_path, modulename=modulename
     )
 
     interface.write_text(content)

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.1.0"
+version = "1.1.1"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://github.com/davidvujic/python-polylith"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes an issue with the Python create-module template, that happens when passing in a `--name` that is a path (containing `/`).

## Motivation and Context
Fixes #46 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
CircleCI ✅ 
REPL-based tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
