### PR TITLE
fix(create-project): the new description feature caused create project to fail

### DIFF
--- a/components/polylith/poetry/commands/create_project.py
+++ b/components/polylith/poetry/commands/create_project.py
@@ -12,6 +12,13 @@ class CreateProjectCommand(Command):
 
     options = [
         option("name", None, "Name of the project.", flag=False),
+        option(
+            "description",
+            None,
+            "Description of the project.",
+            flag=False,
+            value_required=False,
+        ),
     ]
 
     def handle(self) -> int:

--- a/components/polylith/project/create.py
+++ b/components/polylith/project/create.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Union
 
 import tomlkit
 from polylith import repo
@@ -9,7 +10,7 @@ template = """\
 [tool.poetry]
 name = "{name}"
 version = "0.1.0"
-description = ""
+description = "{description}"
 authors = {authors}
 license = ""
 
@@ -33,20 +34,31 @@ def get_workspace_toml(path: Path) -> dict:
     return data
 
 
-def create_project_toml(name, template, workspace_toml) -> tomlkit.TOMLDocument:
+def create_project_toml(
+    name: str, template: str, workspace_toml: dict, description: str
+) -> tomlkit.TOMLDocument:
     authors = workspace_toml["tool"]["poetry"]["authors"]
     python_version = workspace_toml["tool"]["poetry"]["dependencies"]["python"]
 
-    content = template.format(name=name, authors=authors, python_version=python_version)
+    content = template.format(
+        name=name,
+        description=description,
+        authors=authors,
+        python_version=python_version,
+    )
 
     return tomlkit.loads(content)
 
 
-def create_project(path: Path, namespace: str, name: str) -> None:
+def create_project(
+    path: Path, namespace: str, name: str, description: Union[str, None]
+) -> None:
     d = create_dir(path, f"{projects_dir}/{name}")
 
     workspace_toml = get_workspace_toml(path)
-    project_toml = create_project_toml(name, template, workspace_toml)
+    project_toml = create_project_toml(
+        name, template, workspace_toml, description or ""
+    )
 
     fullpath = d / repo.default_toml
 

--- a/projects/poetry_polylith_plugin/README.md
+++ b/projects/poetry_polylith_plugin/README.md
@@ -58,17 +58,18 @@ Add a base:
 poetry poly create base --name my_example_aws_lambda
 ```
 
-##### Options
-`--description`
-Add a brick description. Will be added as a docstring, and in the brick-specific README
-(if it is enabled in the `resources` section of the workspace config).
-
 Add a project:
 
 ``` shell
 # This command will create a project - i.e. a pyproject.toml in a project folder. No code in this folder.
 poetry poly create project --name my_example_aws_lambada_project
 ```
+
+##### Options
+`--description`
+Add a brick description. The description will be added as a docstring.
+Also in the brick-specific README (when set to enabled in the `resources` section of the workspace config).
+
 
 #### Info
 Show info about the workspace:

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.2.0"
+version = "1.2.1"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://github.com/davidvujic/python-polylith"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The new description feature, released in v1.2.0 #50,  caused `create project` to fail.

This PR will fix that, and also enable the `--description` option into `pyproject.toml` files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
