### PR TITLE
fix(poly info): exclude common Python cache folders when listing bricks

### DIFF
--- a/components/polylith/bricks/component.py
+++ b/components/polylith/bricks/component.py
@@ -7,9 +7,15 @@ from polylith.repo import components_dir
 from polylith.test import create_test
 
 
-def create_component(path: Path, namespace: str, package: str, description: Union[str, None]) -> None:
+def create_component(
+    path: Path, namespace: str, package: str, description: Union[str, None]
+) -> None:
     create_brick(path, components_dir, namespace, package, description)
     create_test(path, components_dir, namespace, package)
+
+
+def is_brick_dir(p: Path) -> bool:
+    return p.is_dir() and p.name not in {"__pycache__", ".venv", ".mypy_cache"}
 
 
 def get_component_dirs(root: Path, top_dir, ns) -> list:
@@ -21,7 +27,7 @@ def get_component_dirs(root: Path, top_dir, ns) -> list:
     if not component_dir.exists():
         return []
 
-    return [f for f in component_dir.iterdir() if f.is_dir()]
+    return [f for f in component_dir.iterdir() if is_brick_dir(f)]
 
 
 def get_components_data(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Listing bricks shouldn't include common Python cache folders, like `__pycache__`. This PR will handle that, by checking for common cache folder names.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #65 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Copied a `__pycache__` folder among the compontents.
Ran `poetry poly info` to verify it was there among bricks.
Locally installed the fix, and ran the same command. Verified the `__pycache__` folder was not in the list of bricks.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
