### PR TITLE
fix: poly info, sorted projects

### DIFF
--- a/components/polylith/project/__init__.py
+++ b/components/polylith/project/__init__.py
@@ -1,15 +1,10 @@
 from polylith.project.create import create_project
-from polylith.project.get import (
-    get_packages_for_projects,
-    get_project_name,
-    get_project_names_and_paths,
-)
+from polylith.project.get import get_packages_for_projects, get_project_name
 from polylith.project.parser import parse_package_paths
 
 __all__ = [
     "create_project",
     "get_project_name",
-    "get_project_names_and_paths",
     "get_packages_for_projects",
     "parse_package_paths",
 ]

--- a/components/polylith/project/get.py
+++ b/components/polylith/project/get.py
@@ -39,11 +39,3 @@ def get_packages_for_projects(root: Path) -> List[dict]:
         }
         for d in tomls
     ]
-
-
-def get_project_names_and_paths(root: Path) -> List[dict]:
-    project_files = get_project_files(root)
-
-    return [
-        {"name": get_project_name(get_toml(p)), "path": p.parent} for p in project_files
-    ]

--- a/components/polylith/project/get.py
+++ b/components/polylith/project/get.py
@@ -1,4 +1,3 @@
-from collections.abc import Generator
 from pathlib import Path
 from typing import List
 
@@ -19,8 +18,8 @@ def get_toml(root: Path) -> tomlkit.TOMLDocument:
         return tomlkit.loads(f.read())
 
 
-def get_project_files(root: Path) -> Generator:
-    return root.glob(f"projects/**/{default_toml}")
+def get_project_files(root: Path) -> List[Path]:
+    return sorted(root.glob(f"projects/**/{default_toml}"))
 
 
 def get_toml_files(root: Path) -> List[dict]:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When displaying the table with bricks and projects, the `poetry poly info` command should sort the projects alphabetically.

Also: removed unused function in the `projects` component.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #64 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
1. Verified that projects are not sorted alphabetically, by running `poetry poly info` in the python-polylith-microservices-example workspace.
2. installed an updated, that is sorting projects
3. ran the same command again and confirmed that the sort order was: api_app, worker_1, worker_2.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
