### PR TITLE
Poly diff short double names reported

### DIFF
--- a/components/polylith/diff/collect.py
+++ b/components/polylith/diff/collect.py
@@ -5,14 +5,16 @@ from typing import List, Union
 from polylith import repo, workspace
 
 
-def _parse_brick_name(folder: str, changed_file: Path) -> str:
+def _parse_folder_parts(folder: str, changed_file: Path) -> str:
     file_path = Path(changed_file.as_posix().replace(folder, ""))
 
     return next(p for p in file_path.parts if p != file_path.root)
 
 
 def _get_changed(folder: str, changed_files: List[Path]) -> set:
-    return {_parse_brick_name(folder, f) for f in changed_files if folder in f.as_posix()}
+    return {
+        _parse_folder_parts(folder, f) for f in changed_files if folder in f.as_posix()
+    }
 
 
 def _get_changed_bricks(

--- a/components/polylith/diff/report.py
+++ b/components/polylith/diff/report.py
@@ -78,7 +78,7 @@ def _changed_projects(
     projects_data: List[dict], brick_type: str, bricks: List[str]
 ) -> set:
     res = {
-        p["name"]: set(p.get(brick_type, [])).intersection(bricks)
+        p["path"].name: set(p.get(brick_type, [])).intersection(bricks)
         for p in projects_data
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The command targeting CI deploys, reports double names for a single changed project: the folder name, and the actual project name.

This PR will make sure the __folder__ name is used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #68 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
1. Changed one or more components, change something in the actual project file (such as the pyproject.toml itself)
2. ran `poetry poly diff --short`
3. maked sure only one project is listed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
