### PR TITLE
fix(poly libs): calculate brick import diff by close matches

### DIFF
--- a/components/polylith/libs/report.py
+++ b/components/polylith/libs/report.py
@@ -44,15 +44,15 @@ def flatten_brick_imports(brick_imports: dict) -> Set[str]:
     return set().union(bases_imports, components_imports)
 
 
-def filter_close_matches(imports: Set[str], deps: Set[str]) -> Set[str]:
-    return {i for i in imports if not difflib.get_close_matches(i, deps)}
+def filter_close_matches(unknown_imports: Set[str], deps: Set[str]) -> Set[str]:
+    return {u for u in unknown_imports if not difflib.get_close_matches(u, deps)}
 
 
 def calculate_diff(brick_imports: dict, deps: Set[str]) -> Set[str]:
     imports = flatten_brick_imports(brick_imports)
-    unknown = imports.difference(deps)
+    unknown_imports = imports.difference(deps)
 
-    return filter_close_matches(unknown, imports)
+    return filter_close_matches(unknown_imports, deps)
 
 
 def print_libs_summary(brick_imports: dict, project_data: dict) -> None:

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.5.0"
+version = "1.5.1"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,4 +49,4 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-addopts = "-v --cov=components --cov-branch --cov-report=term-missing"
+addopts = "-sv"

--- a/test/components/polylith/libs/test_report.py
+++ b/test/components/polylith/libs/test_report.py
@@ -1,0 +1,70 @@
+from polylith.libs import report
+
+
+def test_calculate_diff_reports_no_diff():
+    brick_imports = {
+        "bases": {"my_base": {"rich"}},
+        "components": {
+            "one": {"rich"},
+            "two": {"rich", "cleo"},
+            "thre": {"tomlkit"},
+        },
+    }
+
+    third_party_libs = {
+        "tomlkit",
+        "cleo",
+        "requests",
+        "rich",
+    }
+
+    res = report.calculate_diff(brick_imports, third_party_libs)
+
+    assert len(res) == 0
+
+
+def test_calculate_diff_should_report_missing_dependency():
+    expected_missing = "aws-lambda-powertools"
+
+    brick_imports = {
+        "bases": {"my_base": {"poetry"}},
+        "components": {
+            "one": {"tomlkit"},
+            "two": {"tomlkit", expected_missing, "rich"},
+            "three": {"rich"},
+        },
+    }
+
+    third_party_libs = {
+        "tomlkit",
+        "poetry",
+        "mypy-extensions",
+        "rich",
+    }
+
+    res = report.calculate_diff(brick_imports, third_party_libs)
+
+    assert res == {expected_missing}
+
+
+def test_calculate_diff_should_identify_close_match():
+    brick_imports = {
+        "bases": {"my_base": {"poetry"}},
+        "components": {
+            "one": {"tomlkit"},
+            "two": {"tomlkit", "aws_lambda_powertools", "rich"},
+            "three": {"rich", "pyyoutube"},
+        },
+    }
+
+    third_party_libs = {
+        "tomlkit",
+        "python-youtube",
+        "poetry",
+        "aws-lambda-powertools",
+        "rich",
+    }
+
+    res = report.calculate_diff(brick_imports, third_party_libs)
+
+    assert len(res) == 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The current calculation of missing third-party libs is naive and will fail on libraries that differ in the name stated in `pyproject.toml` and the actual thing that is imported in python code.

This PR aims to calculate the diff by using "close matches".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #75 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manual install
CircleCI ✅ 
Added unit tests for changed feature.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
