### PR TITLE
fix(poly info): handle missing packages section.

### DIFF
--- a/components/polylith/project/get.py
+++ b/components/polylith/project/get.py
@@ -6,7 +6,7 @@ from polylith.repo import default_toml
 
 
 def get_project_package_includes(data) -> List[dict]:
-    return data["tool"]["poetry"]["packages"]
+    return data["tool"]["poetry"].get("packages", [])
 
 
 def get_project_name(data) -> str:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Soft-get the `packages` section from a pyproject.toml file. This is because, since Poetry v1.4, a new project file doesn't contain that as default. For Polylith, this means when initializing a new repo and a new poetry project using `poetry init` according to the setup guide.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local install and manual test.
CircleCI ✅ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
