### PR TITLE
Add poly sync

### DIFF
--- a/bases/polylith/poetry_plugin/plugin.py
+++ b/bases/polylith/poetry_plugin/plugin.py
@@ -9,6 +9,7 @@ from polylith.poetry.commands import (
     DiffCommand,
     InfoCommand,
     LibsCommand,
+    SyncCommand,
 )
 
 commands = [
@@ -20,6 +21,7 @@ commands = [
     DiffCommand,
     InfoCommand,
     LibsCommand,
+    SyncCommand,
 ]
 
 

--- a/components/polylith/check/report.py
+++ b/components/polylith/check/report.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Set
 
-from polylith import libs, workspace
+from polylith import imports, libs, workspace
 from polylith.check import grouping
 from rich.console import Console
 from rich.theme import Theme
@@ -41,8 +41,8 @@ def print_report(
     bases_paths = workspace.paths.collect_bases_paths(root, ns, bases)
     components_paths = workspace.paths.collect_components_paths(root, ns, components)
 
-    all_imports_in_bases = libs.fetch_all_imports(bases_paths)
-    all_imports_in_components = libs.fetch_all_imports(components_paths)
+    all_imports_in_bases = imports.fetch_all_imports(bases_paths)
+    all_imports_in_components = imports.fetch_all_imports(components_paths)
 
     brick_imports = {
         "bases": grouping.extract_brick_imports(all_imports_in_bases, ns),

--- a/components/polylith/check/report.py
+++ b/components/polylith/check/report.py
@@ -3,17 +3,8 @@ from typing import Set
 
 from polylith import imports, libs, workspace
 from polylith.check import grouping
+from polylith.reporting import theme
 from rich.console import Console
-from rich.theme import Theme
-
-info_theme = Theme(
-    {
-        "data": "#999966",
-        "proj": "#8A2BE2",
-        "comp": "#32CD32",
-        "base": "#6495ED",
-    }
-)
 
 
 def print_missing_deps(brick_imports: dict, deps: Set[str], project_name: str) -> bool:
@@ -22,7 +13,7 @@ def print_missing_deps(brick_imports: dict, deps: Set[str], project_name: str) -
     if not diff:
         return True
 
-    console = Console(theme=info_theme)
+    console = Console(theme=theme.poly_theme)
 
     missing = ", ".join(sorted(diff))
 

--- a/components/polylith/diff/report.py
+++ b/components/polylith/diff/report.py
@@ -1,20 +1,11 @@
 from typing import List
 
+from polylith.reporting import theme
 from rich import box
 from rich.columns import Columns
 from rich.console import Console
 from rich.padding import Padding
 from rich.table import Table
-from rich.theme import Theme
-
-info_theme = Theme(
-    {
-        "data": "#999966",
-        "proj": "#8A2BE2",
-        "comp": "#32CD32",
-        "base": "#6495ED",
-    }
-)
 
 
 def brick_status(brick, bricks) -> str:
@@ -30,7 +21,7 @@ def print_diff_details(
     if not bases and not components:
         return
 
-    console = Console(theme=info_theme)
+    console = Console(theme=theme.poly_theme)
     table = Table(box=box.SIMPLE_HEAD)
     table.add_column("[data]changed brick[/]")
 
@@ -52,14 +43,14 @@ def print_detected_changes_in_projects(projects: List[str]) -> None:
     if not projects:
         return
 
-    console = Console(theme=info_theme)
+    console = Console(theme=theme.poly_theme)
 
     for project in sorted(projects):
         console.print(f"[data]:gear: Changes found in [/][proj]{project}[/]")
 
 
 def print_diff_summary(tag: str, bases: List[str], components: List[str]) -> None:
-    console = Console(theme=info_theme)
+    console = Console(theme=theme.poly_theme)
 
     console.print(Padding(f"[data]Diff: based on the {tag} tag[/]", (1, 0, 1, 0)))
 
@@ -98,5 +89,5 @@ def print_short_diff(
 
     res = {*a, *b, *c}
 
-    console = Console(theme=info_theme)
+    console = Console(theme=theme.poly_theme)
     console.print(",".join(res))

--- a/components/polylith/imports/__init__.py
+++ b/components/polylith/imports/__init__.py
@@ -1,0 +1,3 @@
+from polylith.imports.parser import extract_top_ns, fetch_all_imports, list_imports
+
+__all__ = ["extract_top_ns", "fetch_all_imports", "list_imports"]

--- a/components/polylith/imports/parser.py
+++ b/components/polylith/imports/parser.py
@@ -1,5 +1,5 @@
 import ast
-import pathlib
+from pathlib import Path
 from typing import List, Set
 
 
@@ -29,23 +29,37 @@ def parse_imports(node: ast.AST) -> List[str]:
     return []
 
 
-def parse_module(path: pathlib.Path) -> ast.AST:
+def parse_module(path: Path) -> ast.AST:
     with open(path.as_posix(), "r", encoding="utf-8", errors="ignore") as f:
         tree = ast.parse(f.read(), path.name)
 
     return tree
 
 
-def extract_imports(path: pathlib.Path) -> List[str]:
+def extract_imports(path: Path) -> List[str]:
     tree = parse_module(path)
 
     return [i for node in ast.walk(tree) for i in parse_imports(node) if i is not None]
 
 
-def list_imports(path: pathlib.Path) -> Set[str]:
+def list_imports(path: Path) -> Set[str]:
     py_modules = path.rglob("*.py")
 
     extracted = (extract_imports(m) for m in py_modules)
     flattened = (i for imports in extracted for i in imports)
 
     return set(flattened)
+
+
+def fetch_all_imports(paths: Set[Path]) -> dict:
+    rows = [{p.name: list_imports(p)} for p in paths]
+
+    return {k: v for row in rows for k, v in row.items()}
+
+
+def extract_top_ns_from_imports(imports: Set[str]) -> Set:
+    return {imp.split(".")[0] for imp in imports}
+
+
+def extract_top_ns(import_data: dict) -> dict:
+    return {k: extract_top_ns_from_imports(v) for k, v in import_data.items()}

--- a/components/polylith/info/report.py
+++ b/components/polylith/info/report.py
@@ -1,20 +1,11 @@
 from typing import List
 
+from polylith.reporting import theme
 from rich import box
 from rich.columns import Columns
 from rich.console import Console
 from rich.padding import Padding
 from rich.table import Table
-from rich.theme import Theme
-
-info_theme = Theme(
-    {
-        "data": "#999966",
-        "proj": "#8A2BE2",
-        "comp": "#32CD32",
-        "base": "#6495ED",
-    }
-)
 
 
 def brick_status(brick, bricks) -> str:
@@ -42,7 +33,7 @@ def print_bricks_in_projects(
     if not components and not bases:
         return
 
-    console = Console(theme=info_theme)
+    console = Console(theme=theme.poly_theme)
     table = Table(box=box.SIMPLE_HEAD)
     table.add_column("[data]brick[/]")
 
@@ -63,7 +54,7 @@ def print_bricks_in_projects(
 def print_workspace_summary(
     projects_data: List[dict], bases: List[str], components: List[str]
 ) -> None:
-    console = Console(theme=info_theme)
+    console = Console(theme=theme.poly_theme)
 
     console.print(Padding("[data]Workspace summary[/]", (1, 0, 1, 0)))
 

--- a/components/polylith/libs/__init__.py
+++ b/components/polylith/libs/__init__.py
@@ -1,13 +1,4 @@
 from polylith.libs import report
-from polylith.libs.grouping import (
-    extract_third_party_imports,
-    fetch_all_imports,
-    get_third_party_imports,
-)
+from polylith.libs.grouping import extract_third_party_imports, get_third_party_imports
 
-__all__ = [
-    "report",
-    "extract_third_party_imports",
-    "fetch_all_imports",
-    "get_third_party_imports",
-]
+__all__ = ["report", "extract_third_party_imports", "get_third_party_imports"]

--- a/components/polylith/libs/grouping.py
+++ b/components/polylith/libs/grouping.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Set
 
 from polylith import workspace
-from polylith.libs.imports import list_imports
+from polylith.imports import extract_top_ns, fetch_all_imports
 from polylith.libs.stdlib import standard_libs
 
 
@@ -13,20 +13,6 @@ def get_python_version() -> str:
 
 def get_standard_libs(python_version: str) -> Set[str]:
     return standard_libs.get(python_version, set())
-
-
-def fetch_all_imports(paths: Set[Path]) -> dict:
-    rows = [{p.name: list_imports(p)} for p in paths]
-
-    return {k: v for row in rows for k, v in row.items()}
-
-
-def extract_top_ns_from_imports(imports: Set[str]) -> Set:
-    return {imp.split(".")[0] for imp in imports}
-
-
-def extract_top_ns(import_data: dict) -> dict:
-    return {k: extract_top_ns_from_imports(v) for k, v in import_data.items()}
 
 
 def exclude_libs(import_data: dict, to_exclude: Set) -> dict:

--- a/components/polylith/libs/report.py
+++ b/components/polylith/libs/report.py
@@ -4,20 +4,11 @@ from typing import Set
 
 from polylith import info, workspace
 from polylith.libs import grouping
+from polylith.reporting import theme
 from rich import box
 from rich.console import Console
 from rich.padding import Padding
 from rich.table import Table
-from rich.theme import Theme
-
-info_theme = Theme(
-    {
-        "data": "#999966",
-        "proj": "#8A2BE2",
-        "comp": "#32CD32",
-        "base": "#6495ED",
-    }
-)
 
 
 def get_third_party_imports(root: Path, ns: str, project_data: dict) -> dict:
@@ -56,7 +47,7 @@ def calculate_diff(brick_imports: dict, deps: Set[str]) -> Set[str]:
 
 
 def print_libs_summary(brick_imports: dict, project_data: dict) -> None:
-    console = Console(theme=info_theme)
+    console = Console(theme=theme.poly_theme)
 
     name = project_data["name"]
     is_project = info.is_project(project_data)
@@ -82,7 +73,7 @@ def print_libs_in_bricks(brick_imports: dict) -> None:
     if not bases_imports and not components_imports:
         return
 
-    console = Console(theme=info_theme)
+    console = Console(theme=theme.poly_theme)
     table = Table(box=box.SIMPLE_HEAD)
 
     bases = brick_imports.get("bases", {})
@@ -108,7 +99,7 @@ def print_missing_installed_libs(
     if not diff:
         return True
 
-    console = Console(theme=info_theme)
+    console = Console(theme=theme.poly_theme)
 
     missing = ", ".join(sorted(diff))
 

--- a/components/polylith/poetry/commands/__init__.py
+++ b/components/polylith/poetry/commands/__init__.py
@@ -6,6 +6,7 @@ from polylith.poetry.commands.create_workspace import CreateWorkspaceCommand
 from polylith.poetry.commands.diff import DiffCommand
 from polylith.poetry.commands.info import InfoCommand
 from polylith.poetry.commands.libs import LibsCommand
+from polylith.poetry.commands.sync import SyncCommand
 
 __all__ = [
     "CheckCommand",
@@ -16,4 +17,5 @@ __all__ = [
     "DiffCommand",
     "InfoCommand",
     "LibsCommand",
+    "SyncCommand",
 ]

--- a/components/polylith/poetry/commands/sync.py
+++ b/components/polylith/poetry/commands/sync.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from poetry.console.commands.command import Command
-from polylith import project, repo, sync
+from polylith import project, repo, sync, workspace
 
 
 class SyncCommand(Command):
@@ -22,7 +22,9 @@ class SyncCommand(Command):
             else None
         )
 
-        res = sync.calculate_difference(root, project_name)
+        ns = workspace.parser.get_namespace_from_config(root)
+
+        res = sync.calculate_difference(root, ns, project_name)
 
         print(res)
         return 0

--- a/components/polylith/poetry/commands/sync.py
+++ b/components/polylith/poetry/commands/sync.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from poetry.console.commands.command import Command
+from polylith import info, project, repo, workspace
+
+
+class SyncCommand(Command):
+    name = "poly sync"
+    description = "Update <comment>pyproject.toml</comment> with missing bricks."
+
+    def handle(self) -> int:
+        root = repo.find_workspace_root(Path.cwd())
+
+        if not root:
+            raise ValueError(
+                "Didn't find the workspace root. Expected to find a workspace.toml file."
+            )
+
+        ns = workspace.parser.get_namespace_from_config(root)
+
+        bases = info.get_bases(root, ns)
+        components = info.get_components(root, ns)
+
+        projects_data = info.get_bricks_in_projects(root, components, bases, ns)
+
+        if self.option("directory"):
+            project_name = project.get_project_name(self.poetry.pyproject.data)
+
+            data = next((p for p in projects_data if p["name"] == project_name), None)
+
+            if not data:
+                raise ValueError(f"Didn't find project in {self.option('directory')}")
+
+            res = 0
+            result_code = 0 if res else 1
+        else:
+            # dev_data = [p for p in projects_data if not info.is_project(p)]
+
+            results = [True]
+
+            result_code = 0 if all(results) else 1
+
+        return result_code

--- a/components/polylith/poetry/commands/sync.py
+++ b/components/polylith/poetry/commands/sync.py
@@ -25,7 +25,7 @@ class SyncCommand(Command):
         ns = workspace.parser.get_namespace_from_config(root)
 
         diff = sync.calculate_difference(root, ns, project_name)
-        packages = sync.to_packages(ns, diff["bases"], diff["components"], is_project)
+        packages = sync.to_packages(root, ns, diff["bases"], diff["components"], is_project)
 
         print(diff)
         print(packages)

--- a/components/polylith/poetry/commands/sync.py
+++ b/components/polylith/poetry/commands/sync.py
@@ -27,8 +27,7 @@ class SyncCommand(Command):
         diff = sync.calculate_difference(root, ns, project_name)
         packages = sync.to_packages(root, ns, diff, is_project)
 
-        print(diff)
-        print(packages)
-        # if packages:
-        # sync.update_project(directory or root, packages)
+        if packages:
+            sync.update_project(directory or root, packages)
+
         return 0

--- a/components/polylith/poetry/commands/sync.py
+++ b/components/polylith/poetry/commands/sync.py
@@ -27,17 +27,16 @@ class SyncCommand(Command):
             project_name = project.get_project_name(self.poetry.pyproject.data)
 
             data = next((p for p in projects_data if p["name"] == project_name), None)
-
-            if not data:
-                raise ValueError(f"Didn't find project in {self.option('directory')}")
-
-            res = 0
-            result_code = 0 if res else 1
         else:
-            # dev_data = [p for p in projects_data if not info.is_project(p)]
+            data = next((p for p in projects_data if not info.is_project(p)))
 
-            results = [True]
+        if not data:
+            raise ValueError("Didn't find the project.")
 
-            result_code = 0 if all(results) else 1
+        components_diff = set(components).difference(data["components"])
+        bases_diff = set(bases).difference(data["bases"])
 
-        return result_code
+        print(components_diff)
+        print(bases_diff)
+
+        return 0

--- a/components/polylith/poetry/commands/sync.py
+++ b/components/polylith/poetry/commands/sync.py
@@ -27,6 +27,8 @@ class SyncCommand(Command):
         diff = sync.calculate_difference(root, ns, project_name)
         packages = sync.to_packages(ns, diff["bases"], diff["components"], is_project)
 
-        if packages:
-            sync.update_project(directory or root, packages)
+        print(diff)
+        print(packages)
+        # if packages:
+        # sync.update_project(directory or root, packages)
         return 0

--- a/components/polylith/poetry/commands/sync.py
+++ b/components/polylith/poetry/commands/sync.py
@@ -16,15 +16,17 @@ class SyncCommand(Command):
                 "Didn't find the workspace root. Expected to find a workspace.toml file."
             )
 
+        directory = self.option("directory")
+        is_project = True if directory else False
         project_name = (
-            project.get_project_name(self.poetry.pyproject.data)
-            if self.option("directory")
-            else None
+            project.get_project_name(self.poetry.pyproject.data) if is_project else None
         )
 
         ns = workspace.parser.get_namespace_from_config(root)
 
-        res = sync.calculate_difference(root, ns, project_name)
+        diff = sync.calculate_difference(root, ns, project_name)
+        packages = sync.to_packages(ns, diff["bases"], diff["components"], is_project)
 
-        print(res)
+        if packages:
+            sync.update_project(directory or root, packages)
         return 0

--- a/components/polylith/poetry/commands/sync.py
+++ b/components/polylith/poetry/commands/sync.py
@@ -25,7 +25,7 @@ class SyncCommand(Command):
         ns = workspace.parser.get_namespace_from_config(root)
 
         diff = sync.calculate_difference(root, ns, project_name)
-        packages = sync.to_packages(root, ns, diff["bases"], diff["components"], is_project)
+        packages = sync.to_packages(root, ns, diff, is_project)
 
         print(diff)
         print(packages)

--- a/components/polylith/poetry/commands/sync.py
+++ b/components/polylith/poetry/commands/sync.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import List
 
 from poetry.console.commands.command import Command
 from polylith import info, project, repo, sync, workspace
@@ -7,6 +8,21 @@ from polylith import info, project, repo, sync, workspace
 class SyncCommand(Command):
     name = "poly sync"
     description = "Update <comment>pyproject.toml</comment> with missing bricks."
+
+    def filter_projects_data(self, all_projects_data: List[dict]) -> List[dict]:
+        if self.option("directory"):
+            project_name = project.get_project_name(self.poetry.pyproject.data)
+
+            data = next(
+                (p for p in all_projects_data if p["name"] == project_name), None
+            )
+
+            if not data:
+                raise ValueError(f"Didn't find project in {self.option('directory')}")
+
+            return [data]
+
+        return all_projects_data
 
     def handle(self) -> int:
         root = repo.find_workspace_root(Path.cwd())
@@ -20,24 +36,15 @@ class SyncCommand(Command):
 
         bases = info.get_bases(root, ns)
         components = info.get_components(root, ns)
-
-        projects_data = info.get_bricks_in_projects(root, components, bases, ns)
         workspace_data = {"bases": bases, "components": components}
 
-        if self.option("directory"):
-            project_name = project.get_project_name(self.poetry.pyproject.data)
+        all_projects_data = info.get_bricks_in_projects(root, components, bases, ns)
+        projects_data = self.filter_projects_data(all_projects_data)
 
-            data = next((p for p in projects_data if p["name"] == project_name), None)
-
-            if not data:
-                raise ValueError(f"Didn't find project in {self.option('directory')}")
-
-            diffs = [sync.calculate_diff(root, ns, data, workspace_data)]
-        else:
-            diffs = [
-                sync.calculate_diff(root, ns, data, workspace_data)
-                for data in projects_data
-            ]
+        diffs = [
+            sync.calculate_diff(root, ns, data, workspace_data)
+            for data in projects_data
+        ]
 
         for diff in diffs:
             sync.report.print_summary(diff)

--- a/components/polylith/project/__init__.py
+++ b/components/polylith/project/__init__.py
@@ -1,10 +1,11 @@
 from polylith.project.create import create_project
-from polylith.project.get import get_packages_for_projects, get_project_name
+from polylith.project.get import get_packages_for_projects, get_project_name, get_toml
 from polylith.project.parser import parse_package_paths
 
 __all__ = [
     "create_project",
-    "get_project_name",
     "get_packages_for_projects",
+    "get_project_name",
+    "get_toml",
     "parse_package_paths",
 ]

--- a/components/polylith/project/get.py
+++ b/components/polylith/project/get.py
@@ -13,8 +13,8 @@ def get_project_name(data) -> str:
     return data["tool"]["poetry"]["name"]
 
 
-def get_toml(root: Path) -> tomlkit.TOMLDocument:
-    with root.open(encoding="utf-8", errors="ignore") as f:
+def get_toml(path: Path) -> tomlkit.TOMLDocument:
+    with path.open(encoding="utf-8", errors="ignore") as f:
         return tomlkit.loads(f.read())
 
 

--- a/components/polylith/reporting/__init__.py
+++ b/components/polylith/reporting/__init__.py
@@ -1,4 +1,3 @@
 from polylith.reporting import theme
 
 __all__ = ["theme"]
-

--- a/components/polylith/reporting/__init__.py
+++ b/components/polylith/reporting/__init__.py
@@ -1,0 +1,4 @@
+from polylith.reporting import theme
+
+__all__ = ["theme"]
+

--- a/components/polylith/reporting/theme.py
+++ b/components/polylith/reporting/theme.py
@@ -1,0 +1,10 @@
+from rich.theme import Theme
+
+poly_theme = Theme(
+    {
+        "data": "#999966",
+        "proj": "#8A2BE2",
+        "comp": "#32CD32",
+        "base": "#6495ED",
+    }
+)

--- a/components/polylith/sync/__init__.py
+++ b/components/polylith/sync/__init__.py
@@ -1,4 +1,5 @@
-from polylith.sync.collect import calculate_difference
-from polylith.sync.update import to_packages, update_project
+from polylith.sync import report
+from polylith.sync.collect import calculate_diff
+from polylith.sync.update import update_project
 
-__all__ = ["calculate_difference", "to_packages", "update_project"]
+__all__ = ["report", "calculate_diff", "update_project"]

--- a/components/polylith/sync/__init__.py
+++ b/components/polylith/sync/__init__.py
@@ -1,3 +1,4 @@
 from polylith.sync.collect import calculate_difference
+from polylith.sync.update import to_project_packages, update_project
 
-__all__ = ["calculate_difference"]
+__all__ = ["calculate_difference", "to_project_packages", "update_project"]

--- a/components/polylith/sync/__init__.py
+++ b/components/polylith/sync/__init__.py
@@ -1,3 +1,3 @@
-from polylith.sync import collect
+from polylith.sync.collect import calculate_difference
 
-__all__ = ["collect"]
+__all__ = ["calculate_difference"]

--- a/components/polylith/sync/__init__.py
+++ b/components/polylith/sync/__init__.py
@@ -1,4 +1,4 @@
 from polylith.sync.collect import calculate_difference
-from polylith.sync.update import to_project_packages, update_project
+from polylith.sync.update import to_packages, update_project
 
-__all__ = ["calculate_difference", "to_project_packages", "update_project"]
+__all__ = ["calculate_difference", "to_packages", "update_project"]

--- a/components/polylith/sync/__init__.py
+++ b/components/polylith/sync/__init__.py
@@ -1,4 +1,3 @@
 from polylith.sync import collect
 
 __all__ = ["collect"]
-

--- a/components/polylith/sync/__init__.py
+++ b/components/polylith/sync/__init__.py
@@ -1,0 +1,4 @@
+from polylith.sync import collect
+
+__all__ = ["collect"]
+

--- a/components/polylith/sync/collect.py
+++ b/components/polylith/sync/collect.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from typing import List, Set
+from polylith import info, workspace
+
+
+def find_project_data(project_name: str, projects_data: List[dict]) -> dict:
+    return next(p for p in projects_data if p["name"] == project_name)
+
+
+def find_development_data(projects_data: List[dict]) -> dict:
+    return next(p for p in projects_data if not info.is_project(p))
+
+
+def diff(bricks: List[str], bricks_in_project: Set[str]) -> Set[str]:
+    return set(bricks).difference(bricks_in_project)
+
+
+def calculate_difference(root: Path, project_name: str | None) -> dict:
+    ns = workspace.parser.get_namespace_from_config(root)
+
+    bases = info.get_bases(root, ns)
+    components = info.get_components(root, ns)
+    projects_data = info.get_bricks_in_projects(root, components, bases, ns)
+
+    if project_name:
+        data = find_project_data(project_name, projects_data)
+    else:
+        data = find_development_data(projects_data)
+
+    return {
+        "bases": diff(bases, data["bases"]),
+        "components": diff(components, data["components"]),
+    }

--- a/components/polylith/sync/collect.py
+++ b/components/polylith/sync/collect.py
@@ -1,6 +1,7 @@
 from pathlib import Path
-from typing import List, Set
-from polylith import info, workspace
+from typing import List, Set, Union
+
+from polylith import info
 
 
 def find_project_data(project_name: str, projects_data: List[dict]) -> dict:
@@ -15,12 +16,12 @@ def diff(bricks: List[str], bricks_in_project: Set[str]) -> Set[str]:
     return set(bricks).difference(bricks_in_project)
 
 
-def calculate_difference(root: Path, project_name: str | None) -> dict:
-    ns = workspace.parser.get_namespace_from_config(root)
-
-    bases = info.get_bases(root, ns)
-    components = info.get_components(root, ns)
-    projects_data = info.get_bricks_in_projects(root, components, bases, ns)
+def calculate_difference(
+    root: Path, namespace: str, project_name: Union[str, None]
+) -> dict:
+    bases = info.get_bases(root, namespace)
+    components = info.get_components(root, namespace)
+    projects_data = info.get_bricks_in_projects(root, components, bases, namespace)
 
     if project_name:
         data = find_project_data(project_name, projects_data)

--- a/components/polylith/sync/report.py
+++ b/components/polylith/sync/report.py
@@ -1,18 +1,9 @@
+from polylith.reporting import theme
 from rich.console import Console
-from rich.theme import Theme
-
-info_theme = Theme(
-    {
-        "data": "#999966",
-        "proj": "#8A2BE2",
-        "comp": "#32CD32",
-        "base": "#6495ED",
-    }
-)
 
 
 def print_summary(diff: dict):
-    console = Console(theme=info_theme)
+    console = Console(theme=theme.poly_theme)
 
     name = diff["name"] if diff["is_project"] else "development"
     bases = diff["bases"]

--- a/components/polylith/sync/report.py
+++ b/components/polylith/sync/report.py
@@ -14,7 +14,7 @@ info_theme = Theme(
 def print_summary(diff: dict):
     console = Console(theme=info_theme)
 
-    name = diff["name"]
+    name = diff["name"] if diff["is_project"] else "development"
     bases = diff["bases"]
     components = diff["components"]
 

--- a/components/polylith/sync/report.py
+++ b/components/polylith/sync/report.py
@@ -14,6 +14,24 @@ info_theme = Theme(
 def print_summary(diff: dict):
     console = Console(theme=info_theme)
 
-    project_name = diff["name"]
+    name = diff["name"]
+    bases = diff["bases"]
+    components = diff["components"]
 
-    console.print(f"Synchronizing [proj]{project_name}[/]")
+    anything_to_sync = bases or components
+
+    header = (
+        f":point_right: [proj]{name}[/]"
+        if anything_to_sync
+        else f":heavy_check_mark: [proj]{name}[/]"
+    )
+
+    console.print(header)
+
+    for b in bases:
+        console.print(f"adding [base]{b}[/] base to [proj]{name}[/]")
+
+    for c in components:
+        console.print(f"adding [comp]{c}[/] component to [proj]{name}[/]")
+
+    console.print("")

--- a/components/polylith/sync/report.py
+++ b/components/polylith/sync/report.py
@@ -1,0 +1,19 @@
+from rich.console import Console
+from rich.theme import Theme
+
+info_theme = Theme(
+    {
+        "data": "#999966",
+        "proj": "#8A2BE2",
+        "comp": "#32CD32",
+        "base": "#6495ED",
+    }
+)
+
+
+def print_summary(diff: dict):
+    console = Console(theme=info_theme)
+
+    project_name = diff["name"]
+
+    console.print(f"Synchronizing [proj]{project_name}[/]")

--- a/components/polylith/sync/report.py
+++ b/components/polylith/sync/report.py
@@ -34,4 +34,5 @@ def print_summary(diff: dict):
     for c in components:
         console.print(f"adding [comp]{c}[/] component to [proj]{name}[/]")
 
-    console.print("")
+    if anything_to_sync:
+        console.print("")

--- a/components/polylith/sync/report.py
+++ b/components/polylith/sync/report.py
@@ -5,19 +5,17 @@ from rich.console import Console
 def print_summary(diff: dict):
     console = Console(theme=theme.poly_theme)
 
-    name = diff["name"] if diff["is_project"] else "development"
+    is_project = diff["is_project"]
+    name = diff["name"] if is_project else "development"
     bases = diff["bases"]
     components = diff["components"]
 
     anything_to_sync = bases or components
 
-    header = (
-        f":point_right: [proj]{name}[/]"
-        if anything_to_sync
-        else f":heavy_check_mark: [proj]{name}[/]"
-    )
+    emoji = ":point_right:" if anything_to_sync else ":heavy_check_mark:"
+    printable_name = f"[proj]{name}[/]" if is_project else f"[data]{name}[/]"
 
-    console.print(header)
+    console.print(f"{emoji} {printable_name}")
 
     for b in bases:
         console.print(f"adding [base]{b}[/] base to [proj]{name}[/]")

--- a/components/polylith/sync/update.py
+++ b/components/polylith/sync/update.py
@@ -6,11 +6,10 @@ from polylith import project, repo, workspace
 from tomlkit.toml_document import TOMLDocument
 
 
-def to_package(namespace: str, brick: str, brick_type: str, theme: str, is_project: bool) -> dict:
-    folder = f"{brick_type}" if theme == "loose" else f"{brick_type}/{brick}/src"
-    from_path = f"../../{folder}" if is_project else folder
+def to_package(namespace: str, brick: str, brick_path: str, theme: str) -> dict:
+    folder = f"{brick_path}" if theme == "loose" else f"{brick_path}/{brick}/src"
 
-    return {"include": f"{namespace}/{brick}", "from": from_path}
+    return {"include": f"{namespace}/{brick}", "from": folder}
 
 
 def generate_updated_project(data: TOMLDocument, packages: List[dict]) -> str:
@@ -33,8 +32,11 @@ def to_packages(
 ) -> List[dict]:
     theme = workspace.parser.get_theme_from_config(root)
 
-    a = [to_package(namespace, b, "bases", theme, is_project) for b in bases]
-    b = [to_package(namespace, c, "components", theme, is_project) for c in components]
+    bases_path = "../../bases" if is_project else "bases"
+    components_path = "../../components" if is_project else "components"
+
+    a = [to_package(namespace, b, bases_path, theme) for b in bases]
+    b = [to_package(namespace, c, components_path, theme) for c in components]
 
     return a + b
 

--- a/components/polylith/sync/update.py
+++ b/components/polylith/sync/update.py
@@ -27,8 +27,10 @@ def generate_updated_project(data: TOMLDocument, packages: List[dict]) -> str:
     return tomlkit.dumps(copy)
 
 
-def to_packages(root: Path, namespace: str, diff: dict, is_project: bool) -> List[dict]:
+def to_packages(root: Path, namespace: str, diff: dict) -> List[dict]:
     theme = workspace.parser.get_theme_from_config(root)
+
+    is_project = diff["is_project"]
 
     bases_path = "../../bases" if is_project else "bases"
     components_path = "../../components" if is_project else "components"
@@ -39,7 +41,7 @@ def to_packages(root: Path, namespace: str, diff: dict, is_project: bool) -> Lis
     return a + b
 
 
-def update_project(path: Path, packages: List[dict]) -> None:
+def rewrite_project_file(path: Path, packages: List[dict]):
     fullpath = path / repo.default_toml
     project_toml = project.get_toml(fullpath)
 
@@ -47,3 +49,10 @@ def update_project(path: Path, packages: List[dict]) -> None:
 
     with fullpath.open("w", encoding="utf-8") as f:
         f.write(generated)
+
+
+def update_project(path: Path, namespace: str, diff: dict):
+    packages = to_packages(path, namespace, diff)
+
+    if packages:
+        rewrite_project_file(diff["path"], packages)

--- a/components/polylith/sync/update.py
+++ b/components/polylith/sync/update.py
@@ -2,12 +2,13 @@ from pathlib import Path
 from typing import List, Set
 
 import tomlkit
-from polylith import project, repo
+from polylith import project, repo, workspace
 from tomlkit.toml_document import TOMLDocument
 
 
-def to_package(namespace: str, brick: str, brick_folder: str, is_project: bool) -> dict:
-    from_path = f"../../{brick_folder}" if is_project else brick_folder
+def to_package(namespace: str, brick: str, brick_type: str, theme: str, is_project: bool) -> dict:
+    folder = f"{brick_type}" if theme == "loose" else f"{brick_type}/{brick}/src"
+    from_path = f"../../{folder}" if is_project else folder
 
     return {"include": f"{namespace}/{brick}", "from": from_path}
 
@@ -28,10 +29,12 @@ def generate_updated_project(data: TOMLDocument, packages: List[dict]) -> str:
 
 
 def to_packages(
-    namespace: str, bases: Set[str], components: Set[str], is_project: bool
+    root: Path, namespace: str, bases: Set[str], components: Set[str], is_project: bool
 ) -> List[dict]:
-    a = [to_package(namespace, b, "bases", is_project) for b in bases]
-    b = [to_package(namespace, c, "components", is_project) for c in components]
+    theme = workspace.parser.get_theme_from_config(root)
+
+    a = [to_package(namespace, b, "bases", theme, is_project) for b in bases]
+    b = [to_package(namespace, c, "components", theme, is_project) for c in components]
 
     return a + b
 

--- a/components/polylith/sync/update.py
+++ b/components/polylith/sync/update.py
@@ -6,8 +6,8 @@ from polylith import project, repo
 from tomlkit.toml_document import TOMLDocument
 
 
-def to_package(namespace: str, brick: str, brick_type: str, is_project: bool) -> dict:
-    from_path = f"../../{brick_type}" if is_project else brick_type
+def to_package(namespace: str, brick: str, brick_folder: str, is_project: bool) -> dict:
+    from_path = f"../../{brick_folder}" if is_project else brick_folder
 
     return {"include": f"{namespace}/{brick}", "from": from_path}
 

--- a/components/polylith/sync/update.py
+++ b/components/polylith/sync/update.py
@@ -12,14 +12,14 @@ def to_package(namespace: str, brick: str, brick_folder: str, is_project: bool) 
     return {"include": f"{namespace}/{brick}", "from": from_path}
 
 
-def generate_updated_project(data: TOMLDocument, project_packages: List[dict]) -> str:
+def generate_updated_project(data: TOMLDocument, packages: List[dict]) -> str:
     original = tomlkit.dumps(data)
     copy: dict = tomlkit.parse(original)
 
     if copy["tool"]["poetry"].get("packages") is None:
         copy["tool"]["poetry"].add("packages", [])
 
-    for package in project_packages:
+    for package in packages:
         copy["tool"]["poetry"]["packages"].append(package)
 
     copy["tool"]["poetry"]["packages"].multiline(True)
@@ -27,7 +27,7 @@ def generate_updated_project(data: TOMLDocument, project_packages: List[dict]) -
     return tomlkit.dumps(copy)
 
 
-def to_project_packages(
+def to_packages(
     namespace: str, bases: Set[str], components: Set[str], is_project: bool
 ) -> List[dict]:
     a = [to_package(namespace, b, "bases", is_project) for b in bases]
@@ -36,11 +36,11 @@ def to_project_packages(
     return a + b
 
 
-def update_project(path: Path, project_packages: List[dict]) -> None:
+def update_project(path: Path, packages: List[dict]) -> None:
     fullpath = path / repo.default_toml
     project_toml = project.get_toml(fullpath)
 
-    generated = generate_updated_project(project_toml, project_packages)
+    generated = generate_updated_project(project_toml, packages)
 
     with fullpath.open("w", encoding="utf-8") as f:
         f.write(generated)

--- a/components/polylith/sync/update.py
+++ b/components/polylith/sync/update.py
@@ -27,16 +27,14 @@ def generate_updated_project(data: TOMLDocument, packages: List[dict]) -> str:
     return tomlkit.dumps(copy)
 
 
-def to_packages(
-    root: Path, namespace: str, bases: Set[str], components: Set[str], is_project: bool
-) -> List[dict]:
+def to_packages(root: Path, namespace: str, diff: dict, is_project: bool) -> List[dict]:
     theme = workspace.parser.get_theme_from_config(root)
 
     bases_path = "../../bases" if is_project else "bases"
     components_path = "../../components" if is_project else "components"
 
-    a = [to_package(namespace, b, bases_path, theme) for b in bases]
-    b = [to_package(namespace, c, components_path, theme) for c in components]
+    a = [to_package(namespace, b, bases_path, theme) for b in diff["bases"]]
+    b = [to_package(namespace, c, components_path, theme) for c in diff["components"]]
 
     return a + b
 

--- a/components/polylith/sync/update.py
+++ b/components/polylith/sync/update.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from typing import List, Set
+
+import tomlkit
+from polylith import project, repo
+from tomlkit.toml_document import TOMLDocument
+
+
+def to_package(namespace: str, brick: str, brick_type: str, is_project: bool) -> dict:
+    from_path = f"../../{brick_type}" if is_project else brick_type
+
+    return {"include": f"{namespace}/{brick}", "from": from_path}
+
+
+def generate_updated_project(data: TOMLDocument, project_packages: List[dict]) -> str:
+    original = tomlkit.dumps(data)
+    copy: dict = tomlkit.parse(original)
+
+    if copy["tool"]["poetry"].get("packages") is None:
+        copy["tool"]["poetry"].add("packages", [])
+
+    for package in project_packages:
+        copy["tool"]["poetry"]["packages"].append(package)
+
+    copy["tool"]["poetry"]["packages"].multiline(True)
+
+    return tomlkit.dumps(copy)
+
+
+def to_project_packages(
+    namespace: str, bases: Set[str], components: Set[str], is_project: bool
+) -> List[dict]:
+    a = [to_package(namespace, b, "bases", is_project) for b in bases]
+    b = [to_package(namespace, c, "components", is_project) for c in components]
+
+    return a + b
+
+
+def update_project(path: Path, project_packages: List[dict]) -> None:
+    fullpath = path / repo.default_toml
+    project_toml = project.get_toml(fullpath)
+
+    generated = generate_updated_project(project_toml, project_packages)
+
+    with fullpath.open("w", encoding="utf-8") as f:
+        f.write(generated)

--- a/components/polylith/sync/update.py
+++ b/components/polylith/sync/update.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Set
+from typing import List
 
 import tomlkit
 from polylith import project, repo, workspace

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -14,6 +14,7 @@ packages = [
          {include = "polylith/diff", from = "../../components"},
          {include = "polylith/dirs", from = "../../components"},
          {include = "polylith/files", from = "../../components"},
+         {include = "polylith/imports", from = "../../components"},
          {include = "polylith/info", from = "../../components"},
          {include = "polylith/interface", from = "../../components"},
          {include = "polylith/libs", from = "../../components"},

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.5.2"
+version = "1.6.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
     {include = "polylith/project",from = "../../components"},
     {include = "polylith/readme",from = "../../components"},
     {include = "polylith/repo",from = "../../components"},
-    {include = "polylith/reporting",from = "../../components"}
+    {include = "polylith/reporting",from = "../../components"},
     {include = "polylith/sync",from = "../../components"},
     {include = "polylith/test",from = "../../components"},
     {include = "polylith/workspace",from = "../../components"}

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -7,24 +7,24 @@ homepage = "https://davidvujic.github.io/python-polylith-docs/"
 repository = "https://github.com/davidvujic/python-polylith"
 readme = "README.md"
 packages = [
-         {include = "polylith/poetry_plugin", from = "../../bases"},
-         {include = "polylith/bricks", from = "../../components"},
-         {include = "polylith/check", from = "../../components"},
-         {include = "polylith/development", from = "../../components"},
-         {include = "polylith/diff", from = "../../components"},
-         {include = "polylith/dirs", from = "../../components"},
-         {include = "polylith/files", from = "../../components"},
-         {include = "polylith/imports", from = "../../components"},
-         {include = "polylith/info", from = "../../components"},
-         {include = "polylith/interface", from = "../../components"},
-         {include = "polylith/libs", from = "../../components"},
-         {include = "polylith/poetry", from = "../../components"},
-         {include = "polylith/project", from = "../../components"},
-         {include = "polylith/readme", from = "../../components"},
-         {include = "polylith/repo", from = "../../components"},
-         {include = "polylith/sync", from = "../../components"},
-         {include = "polylith/test", from = "../../components"},
-         {include = "polylith/workspace", from = "../../components"}
+    {include = "polylith/poetry_plugin",from = "../../bases"},
+    {include = "polylith/bricks",from = "../../components"},
+    {include = "polylith/check",from = "../../components"},
+    {include = "polylith/development",from = "../../components"},
+    {include = "polylith/diff",from = "../../components"},
+    {include = "polylith/dirs",from = "../../components"},
+    {include = "polylith/files",from = "../../components"},
+    {include = "polylith/imports",from = "../../components"},
+    {include = "polylith/info",from = "../../components"},
+    {include = "polylith/interface",from = "../../components"},
+    {include = "polylith/libs",from = "../../components"},
+    {include = "polylith/poetry",from = "../../components"},
+    {include = "polylith/project",from = "../../components"},
+    {include = "polylith/readme",from = "../../components"},
+    {include = "polylith/repo",from = "../../components"},
+    {include = "polylith/sync",from = "../../components"},
+    {include = "polylith/test",from = "../../components"},
+    {include = "polylith/workspace",from = "../../components"}
 ]
 
 [tool.poetry.plugins."poetry.application.plugin"]

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -21,6 +21,7 @@ packages = [
          {include = "polylith/project", from = "../../components"},
          {include = "polylith/readme", from = "../../components"},
          {include = "polylith/repo", from = "../../components"},
+         {include = "polylith/sync", from = "../../components"},
          {include = "polylith/test", from = "../../components"},
          {include = "polylith/workspace", from = "../../components"}
 ]

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -22,6 +22,7 @@ packages = [
     {include = "polylith/project",from = "../../components"},
     {include = "polylith/readme",from = "../../components"},
     {include = "polylith/repo",from = "../../components"},
+    {include = "polylith/reporting",from = "../../components"}
     {include = "polylith/sync",from = "../../components"},
     {include = "polylith/test",from = "../../components"},
     {include = "polylith/workspace",from = "../../components"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ packages = [
     {include = "polylith/project",from = "components"},
     {include = "polylith/readme",from = "components"},
     {include = "polylith/repo",from = "components"},
+    {include = "polylith/reporting",from = "components"}
     {include = "polylith/sync",from = "components"},
     {include = "polylith/test",from = "components"},
     {include = "polylith/workspace",from = "components"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,25 +7,25 @@ homepage = "https://github.com/davidvujic/python-polylith"
 repository = "https://github.com/davidvujic/python-polylith"
 readme = "README.md"
 packages = [
-         {include = "polylith/poetry_plugin", from = "bases"},
-         {include = "polylith/bricks", from = "components"},
-         {include = "polylith/check", from = "components"},
-         {include = "polylith/development", from = "components"},
-         {include = "polylith/diff", from = "components"},
-         {include = "polylith/dirs", from = "components"},
-         {include = "polylith/files", from = "components"},
-         {include = "polylith/imports", from = "components"},
-         {include = "polylith/info", from = "components"},
-         {include = "polylith/interface", from = "components"},
-         {include = "polylith/libs", from = "components"},
-         {include = "polylith/poetry", from = "components"},
-         {include = "polylith/project", from = "components"},
-         {include = "polylith/readme", from = "components"},
-         {include = "polylith/repo", from = "components"},
-         {include = "polylith/sync", from = "components"},
-         {include = "polylith/test", from = "components"},
-         {include = "polylith/workspace", from = "components"},
-         {include = "development"}
+    {include = "polylith/poetry_plugin",from = "bases"},
+    {include = "polylith/bricks",from = "components"},
+    {include = "polylith/check",from = "components"},
+    {include = "polylith/development",from = "components"},
+    {include = "polylith/diff",from = "components"},
+    {include = "polylith/dirs",from = "components"},
+    {include = "polylith/files",from = "components"},
+    {include = "polylith/imports",from = "components"},
+    {include = "polylith/info",from = "components"},
+    {include = "polylith/interface",from = "components"},
+    {include = "polylith/libs",from = "components"},
+    {include = "polylith/poetry",from = "components"},
+    {include = "polylith/project",from = "components"},
+    {include = "polylith/readme",from = "components"},
+    {include = "polylith/repo",from = "components"},
+    {include = "polylith/sync",from = "components"},
+    {include = "polylith/test",from = "components"},
+    {include = "polylith/workspace",from = "components"},
+    {include = "development"}
 ]
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ packages = [
          {include = "polylith/project", from = "components"},
          {include = "polylith/readme", from = "components"},
          {include = "polylith/repo", from = "components"},
+         {include = "polylith/sync", from = "components"},
          {include = "polylith/test", from = "components"},
          {include = "polylith/workspace", from = "components"},
          {include = "development"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ packages = [
          {include = "polylith/diff", from = "components"},
          {include = "polylith/dirs", from = "components"},
          {include = "polylith/files", from = "components"},
+         {include = "polylith/imports", from = "components"},
          {include = "polylith/info", from = "components"},
          {include = "polylith/interface", from = "components"},
          {include = "polylith/libs", from = "components"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
     {include = "polylith/project",from = "components"},
     {include = "polylith/readme",from = "components"},
     {include = "polylith/repo",from = "components"},
-    {include = "polylith/reporting",from = "components"}
+    {include = "polylith/reporting",from = "components"},
     {include = "polylith/sync",from = "components"},
     {include = "polylith/test",from = "components"},
     {include = "polylith/workspace",from = "components"},

--- a/test/components/polylith/sync/test_update.py
+++ b/test/components/polylith/sync/test_update.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import tomlkit
 from polylith.sync import update
 
@@ -5,19 +7,34 @@ from polylith.sync import update
 def test_brick_to_pyproject_package():
     ns = "unit_test"
     brick = "greet"
-    brick_folder = "components"
+    brick_type = "components"
+    loose_theme = "loose"
+    tdd_theme = "tdd"
 
-    expected_dev = {"include": f"{ns}/{brick}", "from": brick_folder}
-    expected_proj = {"include": f"{ns}/{brick}", "from": f"../../{brick_folder}"}
+    expected_dev = {"include": f"{ns}/{brick}", "from": brick_type}
+    expected_proj = {"include": f"{ns}/{brick}", "from": f"../../{brick_type}"}
 
-    res_dev = update.to_package(ns, brick, brick_folder, False)
-    res_proj = update.to_package(ns, brick, brick_folder, True)
+    expected_tdd_dev = {"include": f"{ns}/{brick}", "from": f"{brick_type}/{brick}/src"}
+    expected_tdd_proj = {
+        "include": f"{ns}/{brick}",
+        "from": f"../../{brick_type}/{brick}/src",
+    }
+
+    res_dev = update.to_package(ns, brick, brick_type, loose_theme, False)
+    res_proj = update.to_package(ns, brick, brick_type, loose_theme, True)
+
+    res_tdd_dev = update.to_package(ns, brick, brick_type, tdd_theme, False)
+    res_tdd_proj = update.to_package(ns, brick, brick_type, tdd_theme, True)
 
     assert res_dev == expected_dev
     assert res_proj == expected_proj
 
+    assert res_tdd_dev == expected_tdd_dev
+    assert res_tdd_proj == expected_tdd_proj
+
 
 def test_bricks_to_pyproject_packages():
+    root = Path.cwd()
     ns = "unit_test"
     base = "hello"
     component = "world"
@@ -27,7 +44,7 @@ def test_bricks_to_pyproject_packages():
         {"include": f"{ns}/{component}", "from": "components"},
     ]
 
-    res = update.to_packages(ns, {base}, {component}, False)
+    res = update.to_packages(root, ns, {base}, {component}, False)
 
     assert res == expected
 

--- a/test/components/polylith/sync/test_update.py
+++ b/test/components/polylith/sync/test_update.py
@@ -27,7 +27,7 @@ def test_bricks_to_pyproject_packages():
         {"include": f"{ns}/{component}", "from": "components"},
     ]
 
-    res = update.to_project_packages(ns, {base}, {component}, False)
+    res = update.to_packages(ns, {base}, {component}, False)
 
     assert res == expected
 

--- a/test/components/polylith/sync/test_update.py
+++ b/test/components/polylith/sync/test_update.py
@@ -45,9 +45,15 @@ def test_bricks_to_pyproject_packages():
         {"include": f"{ns}/{component}", "from": "components"},
     ]
 
-    res = update.to_packages(
-        root, ns, {"bases": {base}, "components": {component}}, False
-    )
+    diff = {
+        "name": "unit-test",
+        "path": Path.cwd(),
+        "is_project": False,
+        "bases": {base},
+        "components": {component},
+    }
+
+    res = update.to_packages(root, ns, diff)
 
     assert res == expected
 

--- a/test/components/polylith/sync/test_update.py
+++ b/test/components/polylith/sync/test_update.py
@@ -11,20 +11,20 @@ def test_brick_to_pyproject_package():
     loose_theme = "loose"
     tdd_theme = "tdd"
 
-    expected_dev = {"include": f"{ns}/{brick}", "from": brick_type}
-    expected_proj = {"include": f"{ns}/{brick}", "from": f"../../{brick_type}"}
+    expected_dev = {"include": f"{ns}/{brick}", "from": "components"}
+    expected_proj = {"include": f"{ns}/{brick}", "from": "../../components"}
 
-    expected_tdd_dev = {"include": f"{ns}/{brick}", "from": f"{brick_type}/{brick}/src"}
+    expected_tdd_dev = {"include": f"{ns}/{brick}", "from": f"components/{brick}/src"}
     expected_tdd_proj = {
         "include": f"{ns}/{brick}",
-        "from": f"../../{brick_type}/{brick}/src",
+        "from": f"../../components/{brick}/src",
     }
 
-    res_dev = update.to_package(ns, brick, brick_type, loose_theme, False)
-    res_proj = update.to_package(ns, brick, brick_type, loose_theme, True)
+    res_dev = update.to_package(ns, brick, "components", loose_theme)
+    res_proj = update.to_package(ns, brick, "../../components", loose_theme)
 
-    res_tdd_dev = update.to_package(ns, brick, brick_type, tdd_theme, False)
-    res_tdd_proj = update.to_package(ns, brick, brick_type, tdd_theme, True)
+    res_tdd_dev = update.to_package(ns, brick, "components", tdd_theme)
+    res_tdd_proj = update.to_package(ns, brick, "../../components", tdd_theme)
 
     assert res_dev == expected_dev
     assert res_proj == expected_proj

--- a/test/components/polylith/sync/test_update.py
+++ b/test/components/polylith/sync/test_update.py
@@ -43,7 +43,9 @@ def test_bricks_to_pyproject_packages():
         {"include": f"{ns}/{component}", "from": "components"},
     ]
 
-    res = update.to_packages(root, ns, {base}, {component}, False)
+    res = update.to_packages(
+        root, ns, {"bases": {base}, "components": {component}}, False
+    )
 
     assert res == expected
 

--- a/test/components/polylith/sync/test_update.py
+++ b/test/components/polylith/sync/test_update.py
@@ -9,9 +9,11 @@ def test_brick_to_pyproject_package():
     brick = "greet"
     loose_theme = "loose"
     tdd_theme = "tdd"
+    brick_path_dev = "components"
+    brick_path_proj = "../../components"
 
-    expected_dev = {"include": f"{ns}/{brick}", "from": "components"}
-    expected_proj = {"include": f"{ns}/{brick}", "from": "../../components"}
+    expected_dev = {"include": f"{ns}/{brick}", "from": brick_path_dev}
+    expected_proj = {"include": f"{ns}/{brick}", "from": brick_path_proj}
 
     expected_tdd_dev = {"include": f"{ns}/{brick}", "from": f"components/{brick}/src"}
     expected_tdd_proj = {
@@ -19,11 +21,11 @@ def test_brick_to_pyproject_package():
         "from": f"../../components/{brick}/src",
     }
 
-    res_dev = update.to_package(ns, brick, "components", loose_theme)
-    res_proj = update.to_package(ns, brick, "../../components", loose_theme)
+    res_dev = update.to_package(ns, brick, brick_path_dev, loose_theme)
+    res_proj = update.to_package(ns, brick, brick_path_proj, loose_theme)
 
-    res_tdd_dev = update.to_package(ns, brick, "components", tdd_theme)
-    res_tdd_proj = update.to_package(ns, brick, "../../components", tdd_theme)
+    res_tdd_dev = update.to_package(ns, brick, brick_path_dev, tdd_theme)
+    res_tdd_proj = update.to_package(ns, brick, brick_path_proj, tdd_theme)
 
     assert res_dev == expected_dev
     assert res_proj == expected_proj

--- a/test/components/polylith/sync/test_update.py
+++ b/test/components/polylith/sync/test_update.py
@@ -7,7 +7,6 @@ from polylith.sync import update
 def test_brick_to_pyproject_package():
     ns = "unit_test"
     brick = "greet"
-    brick_type = "components"
     loose_theme = "loose"
     tdd_theme = "tdd"
 

--- a/test/components/polylith/sync/test_update.py
+++ b/test/components/polylith/sync/test_update.py
@@ -1,0 +1,53 @@
+import tomlkit
+from polylith.sync import update
+
+
+def test_brick_to_pyproject_package():
+    ns = "unit_test"
+    brick = "greet"
+    brick_folder = "components"
+
+    expected_dev = {"include": f"{ns}/{brick}", "from": brick_folder}
+    expected_proj = {"include": f"{ns}/{brick}", "from": f"../../{brick_folder}"}
+
+    res_dev = update.to_package(ns, brick, brick_folder, False)
+    res_proj = update.to_package(ns, brick, brick_folder, True)
+
+    assert res_dev == expected_dev
+    assert res_proj == expected_proj
+
+
+def test_bricks_to_pyproject_packages():
+    ns = "unit_test"
+    base = "hello"
+    component = "world"
+
+    expected = [
+        {"include": f"{ns}/{base}", "from": "bases"},
+        {"include": f"{ns}/{component}", "from": "components"},
+    ]
+
+    res = update.to_project_packages(ns, {base}, {component}, False)
+
+    assert res == expected
+
+
+def test_generate_updated_project():
+    expected = [
+        {"include": "hello/first", "from": "bases"},
+        {"include": "hello/second", "from": "bases"},
+        {"include": "hello/third", "from": "components"},
+    ]
+
+    data = tomlkit.parse(
+        """\
+[tool.poetry]
+packages = [{include = "hello/first", from = "bases"}]
+"""
+    )
+
+    updated = update.generate_updated_project(data, expected[1:])
+
+    res = tomlkit.parse(updated)["tool"]["poetry"]["packages"]
+
+    assert res == expected


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Keep projects in sync with the actual usage of components in source code.

Introducing a new command: `poetry poly sync`

This command will analyze and synchronize all projects in the workspace, including the development project.
Add the `--directory` flag to analyze one single project only.

For projects: will add missing brick dependencies, if imported by any of the already added ones.
For development: will add all missing dependencies.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
solves #61

During development, it might be a risk of forgetting to add new components to the project specific `pyproject.toml` file actually needing it. Also, the development project should have all components added, to make it possible to run & experiment with bricks.

There's already the `poly info` and `poly check` command to catch any missing dependencies, and the new `sync` command aims to make the developer workflow even smoother, by automatically adding any missing `bricks` to projects in the workspace.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manual install on the developer machine and running the command on polylith workspaces.
CircleCI ✅ 
SonarCloud ✅ 
CodeScene ✅ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
