### PR TITLE
fix(poly sync): find sub imports of unknown bricks

### DIFF
--- a/components/polylith/sync/collect.py
+++ b/components/polylith/sync/collect.py
@@ -59,10 +59,13 @@ def calculate_diff(
         all_bricks = set().union(all_bases, all_components)
         brick_diff = diff(all_bricks, bases, components)
 
+    bases_diff = {b for b in brick_diff if b in all_bases}
+    components_diff = {b for b in brick_diff if b in all_components}
+
     return {
         "name": project_data["name"],
         "path": project_data["path"],
         "is_project": is_project,
-        "bases": {b for b in brick_diff if b in all_bases},
-        "components": {b for b in brick_diff if b in all_components},
+        "bases": bases_diff,
+        "components": components_diff,
     }

--- a/components/polylith/sync/collect.py
+++ b/components/polylith/sync/collect.py
@@ -26,7 +26,9 @@ def with_unknown_components(root: Path, ns: str, brick_imports: dict) -> dict:
     if not extracted:
         return brick_imports
 
-    return with_unknown_components(root, ns, brick_imports | extracted)
+    collected = {**brick_imports, **extracted}
+
+    return with_unknown_components(root, ns, collected)
 
 
 def get_brick_imports(root: Path, ns: str, project_data: dict) -> dict:

--- a/components/polylith/sync/collect.py
+++ b/components/polylith/sync/collect.py
@@ -28,9 +28,9 @@ def diff(known_bricks: Set[str], bases: List[str], components: List[str]) -> Set
     return known_bricks.difference(bricks)
 
 
-def imports_diff(imports: dict, bases: List, components: List) -> Set[str]:
-    flattened_bases = set().union(*imports["bases"].values())
-    flattened_components = set().union(*imports["components"].values())
+def imports_diff(brick_imports: dict, bases: List, components: List) -> Set[str]:
+    flattened_bases = set().union(*brick_imports["bases"].values())
+    flattened_components = set().union(*brick_imports["components"].values())
 
     flattened_imports = set().union(flattened_bases, flattened_components)
 
@@ -43,7 +43,7 @@ def calculate_diff(
     project_data: dict,
     workspace_data: dict,
 ) -> dict:
-    imports = get_brick_imports(root, namespace, project_data)
+    brick_imports = get_brick_imports(root, namespace, project_data)
 
     all_bases = workspace_data["bases"]
     all_components = workspace_data["components"]
@@ -54,7 +54,7 @@ def calculate_diff(
     is_project = info.is_project(project_data)
 
     if is_project:
-        brick_diff = imports_diff(imports, bases, components)
+        brick_diff = imports_diff(brick_imports, bases, components)
     else:
         all_bricks = set().union(all_bases, all_components)
         brick_diff = diff(all_bricks, bases, components)

--- a/components/polylith/workspace/parser.py
+++ b/components/polylith/workspace/parser.py
@@ -1,11 +1,11 @@
-from functools import cache
+from functools import lru_cache
 from pathlib import Path
 
 import tomlkit
 from polylith import repo
 
 
-@cache
+@lru_cache
 def _load_workspace_config(path: Path) -> tomlkit.TOMLDocument:
     fullpath = path / repo.workspace_file
 

--- a/components/polylith/workspace/parser.py
+++ b/components/polylith/workspace/parser.py
@@ -1,9 +1,11 @@
+from functools import cache
 from pathlib import Path
 
 import tomlkit
 from polylith import repo
 
 
+@cache
 def _load_workspace_config(path: Path) -> tomlkit.TOMLDocument:
     fullpath = path / repo.workspace_file
 

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.6.0"
+version = "1.6.1"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Follow the brick imports of unknown bricks and synchronize with the already added ones, by using recursion.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #90 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Locally installed and added two new components to the python-polylith-example:
`hello` and `world`. The existing `message` component is importing `hello`, and `hello` is importing `world`.

Before: only `hello` was added. Now both `hello` and `world` are found and added. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
