### PR TITLE
feat: add support for verbose poly sync and poly check output

### DIFF
--- a/components/polylith/check/__init__.py
+++ b/components/polylith/check/__init__.py
@@ -1,3 +1,3 @@
-from polylith.check import report
+from polylith.check import collect, grouping, report
 
-__all__ = ["report"]
+__all__ = ["collect", "grouping", "report"]

--- a/components/polylith/check/collect.py
+++ b/components/polylith/check/collect.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from typing import List, Set
+
+from polylith import check, imports, workspace
+
+
+def extract_bricks(paths: Set[Path], ns: str) -> dict:
+    all_imports = imports.fetch_all_imports(paths)
+
+    return check.grouping.extract_brick_imports(all_imports, ns)
+
+
+def with_unknown_components(root: Path, ns: str, brick_imports: dict) -> dict:
+    keys = set(brick_imports.keys())
+    values = set().union(*brick_imports.values())
+
+    unknowns = values.difference(keys)
+
+    if not unknowns:
+        return brick_imports
+
+    paths = workspace.paths.collect_components_paths(root, ns, unknowns)
+
+    extracted = extract_bricks(paths, ns)
+
+    if not extracted:
+        return brick_imports
+
+    collected = {**brick_imports, **extracted}
+
+    return with_unknown_components(root, ns, collected)
+
+
+def diff(known_bricks: Set[str], bases: List[str], components: List[str]) -> Set[str]:
+    bricks = set().union(bases, components)
+
+    return known_bricks.difference(bricks)
+
+
+def imports_diff(brick_imports: dict, bases: List, components: List) -> Set[str]:
+    flattened_bases = set().union(*brick_imports["bases"].values())
+    flattened_components = set().union(*brick_imports["components"].values())
+
+    flattened_imports = set().union(flattened_bases, flattened_components)
+
+    return diff(flattened_imports, bases, components)

--- a/components/polylith/check/report.py
+++ b/components/polylith/check/report.py
@@ -23,8 +23,6 @@ def print_brick_imports(brick_imports: dict) -> None:
                 f":information: [data]{key}[/] is importing [data]{', '.join(imports_in_brick)}[/]"
             )
 
-    console.print("")
-
 
 def print_missing_deps(diff: Set[str], project_name: str) -> bool:
     if not diff:

--- a/components/polylith/check/report.py
+++ b/components/polylith/check/report.py
@@ -13,7 +13,7 @@ def print_brick_imports(brick_imports: dict) -> None:
     bases = brick_imports["bases"]
     components = brick_imports["components"]
 
-    bricks = bases | components
+    bricks = {**bases, **components}
 
     for key, values in bricks.items():
         imports_in_brick = values.difference({key})

--- a/components/polylith/check/report.py
+++ b/components/polylith/check/report.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Set
+from typing import Set, Tuple
 
 from polylith import imports, libs, workspace
 from polylith.check import collect, grouping
@@ -19,7 +19,9 @@ def print_brick_imports(brick_imports: dict) -> None:
         imports_in_brick = values.difference({key})
 
         if imports_in_brick:
-            console.print(f":information: [data]{key}[/] is importing [data]{', '.join(imports_in_brick)}[/]")
+            console.print(
+                f":information: [data]{key}[/] is importing [data]{', '.join(imports_in_brick)}[/]"
+            )
 
     console.print("")
 
@@ -43,8 +45,11 @@ def fetch_brick_imports(root: Path, ns: str, all_imports: dict) -> dict:
 
 
 def print_report(
-    root: Path, ns: str, project_data: dict, third_party_libs: Set, is_verbose: bool,
-) -> bool:
+    root: Path,
+    ns: str,
+    project_data: dict,
+    third_party_libs: Set,
+) -> Tuple[bool, dict, dict]:
     name = project_data["name"]
 
     bases = {b for b in project_data.get("bases", [])}
@@ -69,10 +74,7 @@ def print_report(
     brick_diff = collect.imports_diff(brick_imports, list(bases), list(components))
     brick_result = print_missing_deps(brick_diff, name)
 
-    if is_verbose:
-        print_brick_imports(brick_imports)
-
     libs_diff = libs.report.calculate_diff(third_party_imports, third_party_libs)
     libs_result = print_missing_deps(libs_diff, name)
 
-    return all([brick_result, libs_result])
+    return all([brick_result, libs_result]), brick_imports, third_party_imports

--- a/components/polylith/check/report.py
+++ b/components/polylith/check/report.py
@@ -7,6 +7,23 @@ from polylith.reporting import theme
 from rich.console import Console
 
 
+def print_brick_imports(brick_imports: dict) -> None:
+    console = Console(theme=theme.poly_theme)
+
+    bases = brick_imports["bases"]
+    components = brick_imports["components"]
+
+    bricks = bases | components
+
+    for key, values in bricks.items():
+        imports_in_brick = values.difference({key})
+
+        if imports_in_brick:
+            console.print(f":information: [data]{key}[/] is importing [data]{', '.join(imports_in_brick)}[/]")
+
+    console.print("")
+
+
 def print_missing_deps(diff: Set[str], project_name: str) -> bool:
     if not diff:
         return True
@@ -26,7 +43,7 @@ def fetch_brick_imports(root: Path, ns: str, all_imports: dict) -> dict:
 
 
 def print_report(
-    root: Path, ns: str, project_data: dict, third_party_libs: Set
+    root: Path, ns: str, project_data: dict, third_party_libs: Set, is_verbose: bool,
 ) -> bool:
     name = project_data["name"]
 
@@ -51,6 +68,9 @@ def print_report(
 
     brick_diff = collect.imports_diff(brick_imports, list(bases), list(components))
     brick_result = print_missing_deps(brick_diff, name)
+
+    if is_verbose:
+        print_brick_imports(brick_imports)
 
     libs_diff = libs.report.calculate_diff(third_party_imports, third_party_libs)
     libs_result = print_missing_deps(libs_diff, name)

--- a/components/polylith/imports/parser.py
+++ b/components/polylith/imports/parser.py
@@ -1,4 +1,5 @@
 import ast
+from functools import lru_cache
 from pathlib import Path
 from typing import List, Set
 
@@ -29,6 +30,7 @@ def parse_imports(node: ast.AST) -> List[str]:
     return []
 
 
+@lru_cache
 def parse_module(path: Path) -> ast.AST:
     with open(path.as_posix(), "r", encoding="utf-8", errors="ignore") as f:
         tree = ast.parse(f.read(), path.name)

--- a/components/polylith/poetry/commands/check.py
+++ b/components/polylith/poetry/commands/check.py
@@ -27,9 +27,18 @@ class CheckCommand(Command):
 
         try:
             third_party_libs = self.find_third_party_libs(path)
-            return check.report.print_report(
-                root, ns, project_data, third_party_libs, is_verbose
+            res, brick_imports, third_party_imports = check.report.print_report(
+                root,
+                ns,
+                project_data,
+                third_party_libs,
             )
+
+            if is_verbose:
+                check.report.print_brick_imports(brick_imports)
+                check.report.print_brick_imports(third_party_imports)
+
+            return res
         except ValueError as e:
             self.line_error(f"{name}: <error>{e}</error>")
             return False

--- a/components/polylith/poetry/commands/check.py
+++ b/components/polylith/poetry/commands/check.py
@@ -21,12 +21,15 @@ class CheckCommand(Command):
         return {p.name for p in packages}
 
     def print_report(self, root: Path, ns: str, project_data: dict) -> bool:
+        is_verbose = self.option("verbose")
         path = project_data["path"]
         name = project_data["name"]
 
         try:
             third_party_libs = self.find_third_party_libs(path)
-            return check.report.print_report(root, ns, project_data, third_party_libs)
+            return check.report.print_report(
+                root, ns, project_data, third_party_libs, is_verbose
+            )
         except ValueError as e:
             self.line_error(f"{name}: <error>{e}</error>")
             return False

--- a/components/polylith/poetry/commands/sync.py
+++ b/components/polylith/poetry/commands/sync.py
@@ -25,6 +25,8 @@ class SyncCommand(Command):
         return all_projects_data
 
     def handle(self) -> int:
+        is_verbose = self.option("verbose")
+
         root = repo.find_workspace_root(Path.cwd())
 
         if not root:
@@ -49,5 +51,8 @@ class SyncCommand(Command):
         for diff in diffs:
             sync.report.print_summary(diff)
             sync.update_project(root, ns, diff)
+
+            if is_verbose:
+                sync.report.print_brick_imports(diff)
 
         return 0

--- a/components/polylith/sync/collect.py
+++ b/components/polylith/sync/collect.py
@@ -1,34 +1,6 @@
 from pathlib import Path
-from typing import List, Set
 
-from polylith import check, imports, info, workspace
-
-
-def extract_bricks(paths: Set[Path], ns: str) -> dict:
-    all_imports = imports.fetch_all_imports(paths)
-
-    return check.grouping.extract_brick_imports(all_imports, ns)
-
-
-def with_unknown_components(root: Path, ns: str, brick_imports: dict) -> dict:
-    keys = set(brick_imports.keys())
-    values = set().union(*brick_imports.values())
-
-    unknowns = values.difference(keys)
-
-    if not unknowns:
-        return brick_imports
-
-    paths = workspace.paths.collect_components_paths(root, ns, unknowns)
-
-    extracted = extract_bricks(paths, ns)
-
-    if not extracted:
-        return brick_imports
-
-    collected = {**brick_imports, **extracted}
-
-    return with_unknown_components(root, ns, collected)
+from polylith import check, info, workspace
 
 
 def get_brick_imports(root: Path, ns: str, project_data: dict) -> dict:
@@ -38,28 +10,17 @@ def get_brick_imports(root: Path, ns: str, project_data: dict) -> dict:
     bases_paths = workspace.paths.collect_bases_paths(root, ns, bases)
     components_paths = workspace.paths.collect_components_paths(root, ns, components)
 
-    brick_imports_in_bases = extract_bricks(bases_paths, ns)
-    brick_imports_in_components = extract_bricks(components_paths, ns)
+    brick_imports_in_bases = check.collect.extract_bricks(bases_paths, ns)
+    brick_imports_in_components = check.collect.extract_bricks(components_paths, ns)
 
     return {
-        "bases": with_unknown_components(root, ns, brick_imports_in_bases),
-        "components": with_unknown_components(root, ns, brick_imports_in_components),
+        "bases": check.collect.with_unknown_components(
+            root, ns, brick_imports_in_bases
+        ),
+        "components": check.collect.with_unknown_components(
+            root, ns, brick_imports_in_components
+        ),
     }
-
-
-def diff(known_bricks: Set[str], bases: List[str], components: List[str]) -> Set[str]:
-    bricks = set().union(bases, components)
-
-    return known_bricks.difference(bricks)
-
-
-def imports_diff(brick_imports: dict, bases: List, components: List) -> Set[str]:
-    flattened_bases = set().union(*brick_imports["bases"].values())
-    flattened_components = set().union(*brick_imports["components"].values())
-
-    flattened_imports = set().union(flattened_bases, flattened_components)
-
-    return diff(flattened_imports, bases, components)
 
 
 def calculate_diff(
@@ -79,10 +40,10 @@ def calculate_diff(
     is_project = info.is_project(project_data)
 
     if is_project:
-        brick_diff = imports_diff(brick_imports, bases, components)
+        brick_diff = check.collect.imports_diff(brick_imports, bases, components)
     else:
         all_bricks = set().union(all_bases, all_components)
-        brick_diff = diff(all_bricks, bases, components)
+        brick_diff = check.collect.diff(all_bricks, bases, components)
 
     bases_diff = {b for b in brick_diff if b in all_bases}
     components_diff = {b for b in brick_diff if b in all_components}

--- a/components/polylith/sync/collect.py
+++ b/components/polylith/sync/collect.py
@@ -93,4 +93,5 @@ def calculate_diff(
         "is_project": is_project,
         "bases": bases_diff,
         "components": components_diff,
+        "brick_imports": brick_imports,
     }

--- a/components/polylith/sync/report.py
+++ b/components/polylith/sync/report.py
@@ -1,20 +1,12 @@
+from polylith import check
 from polylith.reporting import theme
 from rich.console import Console
 
 
 def print_brick_imports(diff: dict) -> None:
-    console = Console(theme=theme.poly_theme)
-
     brick_imports = diff["brick_imports"]
-    bricks = brick_imports["bases"] | brick_imports["components"]
 
-    for key, values in bricks.items():
-        imports_in_brick = values.difference({key})
-
-        if imports_in_brick:
-            console.print(f":information: [data]{key}[/] is importing [data]{', '.join(imports_in_brick)}[/]")
-
-    console.print("")
+    check.report.print_brick_imports(brick_imports)
 
 
 def print_summary(diff: dict) -> None:

--- a/components/polylith/sync/report.py
+++ b/components/polylith/sync/report.py
@@ -2,7 +2,22 @@ from polylith.reporting import theme
 from rich.console import Console
 
 
-def print_summary(diff: dict):
+def print_brick_imports(diff: dict) -> None:
+    console = Console(theme=theme.poly_theme)
+
+    brick_imports = diff["brick_imports"]
+    bricks = brick_imports["bases"] | brick_imports["components"]
+
+    for key, values in bricks.items():
+        imports_in_brick = values.difference({key})
+
+        if imports_in_brick:
+            console.print(f":information: [data]{key}[/] is importing [data]{', '.join(imports_in_brick)}[/]")
+
+    console.print("")
+
+
+def print_summary(diff: dict) -> None:
     console = Console(theme=theme.poly_theme)
 
     is_project = diff["is_project"]

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.6.2"
+version = "1.7.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- feat: adding support for verbose output from the `poly sync` command, describing components and their imports.
-  fix: `poly check` command failing to report on missing bricks
- feat: adding support for verbose output from the `poly check` command, describing components and their imports.
- fix: cache modules that already have been parsed, when fetching imports

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #101 

Discovered the `poly check` bug during development of the verbose feature, and decided to include a fix in this Pull Request.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local install and test on the python-polylith-example repo.
CI build ✅ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
