### PR TITLE
feat(poly info): adjust view for workspaces with many projects

### DIFF
--- a/components/polylith/poetry/commands/info.py
+++ b/components/polylith/poetry/commands/info.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from cleo.helpers import option
 from poetry.console.commands.command import Command
 from polylith import info, repo, workspace
 
@@ -8,7 +9,18 @@ class InfoCommand(Command):
     name = "poly info"
     description = "Info about the <comment>Polylith</> workspace."
 
+    options = [
+        option(
+            long_name="short",
+            short_name="s",
+            description="Display Workspace Info adjusted for many projects",
+            flag=True,
+        ),
+    ]
+
     def handle(self) -> int:
+        short = self.option("short")
+
         root = repo.find_workspace_root(Path.cwd())
         if not root:
             raise ValueError(
@@ -21,6 +33,6 @@ class InfoCommand(Command):
         projects_data = info.get_bricks_in_projects(root, components, bases, ns)
 
         info.print_workspace_summary(projects_data, bases, components)
-        info.print_bricks_in_projects(projects_data, bases, components)
+        info.print_bricks_in_projects(projects_data, bases, components, short)
 
         return 0

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.7.0"
+version = "1.8.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fix: adjust the columns in the brick usages table when overflow: ellipsis instead of line breaks.

feat: add a `--short` option to the `poly info` command, that will display the brick usage view in a compressed mode.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To display brick usages in projects in a proper way, for workspaces with many projects.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manual install and testing on the python-polylith-example repo, containing 5+ projects.
CI ✅ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
