### PR TITLE
fix(poly check and poly sync): respect the --quiet flag

### DIFF
--- a/components/polylith/check/report.py
+++ b/components/polylith/check/report.py
@@ -24,16 +24,15 @@ def print_brick_imports(brick_imports: dict) -> None:
             )
 
 
-def print_missing_deps(diff: Set[str], project_name: str) -> bool:
+def print_missing_deps(diff: Set[str], project_name: str) -> None:
     if not diff:
-        return True
+        return
 
     console = Console(theme=theme.poly_theme)
 
     missing = ", ".join(sorted(diff))
 
     console.print(f":thinking_face: Cannot locate {missing} in {project_name}")
-    return False
 
 
 def fetch_brick_imports(root: Path, ns: str, all_imports: dict) -> dict:
@@ -42,14 +41,12 @@ def fetch_brick_imports(root: Path, ns: str, all_imports: dict) -> dict:
     return collect.with_unknown_components(root, ns, extracted)
 
 
-def print_report(
+def create_report(
     root: Path,
     ns: str,
     project_data: dict,
     third_party_libs: Set,
-) -> Tuple[bool, dict, dict]:
-    name = project_data["name"]
-
+) -> Tuple[bool, dict]:
     bases = {b for b in project_data.get("bases", [])}
     components = {c for c in project_data.get("components", [])}
 
@@ -70,9 +67,15 @@ def print_report(
     }
 
     brick_diff = collect.imports_diff(brick_imports, list(bases), list(components))
-    brick_result = print_missing_deps(brick_diff, name)
-
     libs_diff = libs.report.calculate_diff(third_party_imports, third_party_libs)
-    libs_result = print_missing_deps(libs_diff, name)
 
-    return all([brick_result, libs_result]), brick_imports, third_party_imports
+    res = all([not brick_diff, not libs_diff])
+
+    report_details = {
+        "brick_imports": brick_imports,
+        "third_party_imports": third_party_imports,
+        "brick_diff": brick_diff,
+        "libs_diff": libs_diff,
+    }
+
+    return res, report_details

--- a/components/polylith/poetry/commands/check.py
+++ b/components/polylith/poetry/commands/check.py
@@ -22,21 +22,29 @@ class CheckCommand(Command):
 
     def print_report(self, root: Path, ns: str, project_data: dict) -> bool:
         is_verbose = self.option("verbose")
+        is_quiet = self.option("quiet")
+
         path = project_data["path"]
         name = project_data["name"]
 
         try:
             third_party_libs = self.find_third_party_libs(path)
-            res, brick_imports, third_party_imports = check.report.print_report(
+            res, details = check.report.create_report(
                 root,
                 ns,
                 project_data,
                 third_party_libs,
             )
 
+            if is_quiet:
+                return res
+
+            check.report.print_missing_deps(details["brick_diff"], name)
+            check.report.print_missing_deps(details["libs_diff"], name)
+
             if is_verbose:
-                check.report.print_brick_imports(brick_imports)
-                check.report.print_brick_imports(third_party_imports)
+                check.report.print_brick_imports(details["brick_imports"])
+                check.report.print_brick_imports(details["third_party_imports"])
 
             return res
         except ValueError as e:

--- a/components/polylith/poetry/commands/sync.py
+++ b/components/polylith/poetry/commands/sync.py
@@ -26,6 +26,7 @@ class SyncCommand(Command):
 
     def handle(self) -> int:
         is_verbose = self.option("verbose")
+        is_quiet = self.option("quiet")
 
         root = repo.find_workspace_root(Path.cwd())
 
@@ -49,8 +50,12 @@ class SyncCommand(Command):
         ]
 
         for diff in diffs:
-            sync.report.print_summary(diff)
             sync.update_project(root, ns, diff)
+
+            if is_quiet:
+                continue
+
+            sync.report.print_summary(diff)
 
             if is_verbose:
                 sync.report.print_brick_imports(diff)

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.8.2"
+version = "1.8.3"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Run the `poly sync` and `poly check` without any output when passing in the `--quiet` flag.

The `poly check` command does already return an error code (1) to the stdout when there's missing dependencies or bricks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #109 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Local install, running all commands on the `python-polylith-example` repo. Running the `check` and `sync` commands with the `--quiet` flag.
- CircleCI tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
