### PR TITLE
feat(poly check and libs): add --strict option

### DIFF
--- a/components/polylith/check/report.py
+++ b/components/polylith/check/report.py
@@ -46,6 +46,7 @@ def create_report(
     ns: str,
     project_data: dict,
     third_party_libs: Set,
+    is_strict: bool = False
 ) -> Tuple[bool, dict]:
     bases = {b for b in project_data.get("bases", [])}
     components = {c for c in project_data.get("components", [])}
@@ -67,7 +68,7 @@ def create_report(
     }
 
     brick_diff = collect.imports_diff(brick_imports, list(bases), list(components))
-    libs_diff = libs.report.calculate_diff(third_party_imports, third_party_libs)
+    libs_diff = libs.report.calculate_diff(third_party_imports, third_party_libs, is_strict)
 
     res = all([not brick_diff, not libs_diff])
 

--- a/components/polylith/check/report.py
+++ b/components/polylith/check/report.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Set, Tuple
+from typing import Set
 
 from polylith import imports, libs, workspace
 from polylith.check import collect, grouping

--- a/components/polylith/poetry/commands/check.py
+++ b/components/polylith/poetry/commands/check.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Set, Union
 
+from cleo.helpers import option
 from poetry.console.commands.command import Command
 from poetry.factory import Factory
 from polylith import check, info, project, repo, workspace
@@ -9,6 +10,14 @@ from polylith import check, info, project, repo, workspace
 class CheckCommand(Command):
     name = "poly check"
     description = "Validates the <comment>Polylith</> workspace."
+
+    options = [
+        option(
+            long_name="strict",
+            description="More strict checks when matching name of third-party libraries and imports",
+            flag=True,
+        ),
+    ]
 
     def find_third_party_libs(self, path: Union[Path, None]) -> Set:
         project_poetry = Factory().create_poetry(path) if path else self.poetry
@@ -23,6 +32,7 @@ class CheckCommand(Command):
     def print_report(self, root: Path, ns: str, project_data: dict) -> bool:
         is_verbose = self.option("verbose")
         is_quiet = self.option("quiet")
+        is_strict = self.option("strict")
 
         path = project_data["path"]
         name = project_data["name"]
@@ -34,6 +44,7 @@ class CheckCommand(Command):
                 ns,
                 project_data,
                 third_party_libs,
+                is_strict,
             )
 
             if is_quiet:

--- a/components/polylith/poetry/commands/check.py
+++ b/components/polylith/poetry/commands/check.py
@@ -38,14 +38,17 @@ class CheckCommand(Command):
         name = project_data["name"]
 
         try:
+            collected_imports = check.report.collect_all_imports(root, ns, project_data)
             third_party_libs = self.find_third_party_libs(path)
-            res, details = check.report.create_report(
-                root,
-                ns,
+
+            details = check.report.create_report(
                 project_data,
+                collected_imports,
                 third_party_libs,
                 is_strict,
             )
+
+            res = all([not details["brick_diff"], not details["libs_diff"]])
 
             if is_quiet:
                 return res


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `--strict` option has a more narrow way of comparing third-party libraries and the actual imports. This is useful to rule out possible false positives.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Partially solves #107 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manual install and run `check` and `libs` with, and without the `--strict` option. 

- Without: the `geopandas` import will be considered as "ok" because the `pandas` library is installed.
- With the `--strict` option: geopandas will be in the list of unknown imports.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
