### PR TITLE
feat(poly check and libs): add --alias option

### DIFF
--- a/components/polylith/alias/__init__.py
+++ b/components/polylith/alias/__init__.py
@@ -1,0 +1,3 @@
+from polylith.alias.core import parse, pick
+
+__all__ = ["parse", "pick"]

--- a/components/polylith/alias/core.py
+++ b/components/polylith/alias/core.py
@@ -1,0 +1,23 @@
+from functools import reduce
+from typing import List, Set
+
+
+def _to_key_with_values(acc: dict, alias: str) -> dict:
+    k, v = str.split(alias, "=")
+
+    values = [str.strip(val) for val in str.split(v, ",")]
+
+    return {**acc, **{k: values}}
+
+
+def parse(aliases: list[str]) -> dict[str, List[str]]:
+    """Parse a list of aliases defined as key=value(s) into a dictionary"""
+    return reduce(_to_key_with_values, aliases, {})
+
+
+def pick(aliases: dict[str, List[str]], keys: Set) -> Set:
+    matrix = [v for k, v in aliases.items() if k in keys]
+
+    flattened: List = sum(matrix, [])
+
+    return set(flattened)

--- a/components/polylith/alias/core.py
+++ b/components/polylith/alias/core.py
@@ -1,8 +1,8 @@
 from functools import reduce
-from typing import List, Set
+from typing import Dict, List, Set
 
 
-def _to_key_with_values(acc: dict, alias: str) -> dict:
+def _to_key_with_values(acc: Dict, alias: str) -> Dict:
     k, v = str.split(alias, "=")
 
     values = [str.strip(val) for val in str.split(v, ",")]
@@ -10,12 +10,12 @@ def _to_key_with_values(acc: dict, alias: str) -> dict:
     return {**acc, **{k: values}}
 
 
-def parse(aliases: list[str]) -> dict[str, List[str]]:
+def parse(aliases: List[str]) -> Dict[str, List[str]]:
     """Parse a list of aliases defined as key=value(s) into a dictionary"""
     return reduce(_to_key_with_values, aliases, {})
 
 
-def pick(aliases: dict[str, List[str]], keys: Set) -> Set:
+def pick(aliases: Dict[str, List[str]], keys: Set) -> Set:
     matrix = [v for k, v in aliases.items() if k in keys]
 
     flattened: List = sum(matrix, [])

--- a/components/polylith/poetry/commands/check.py
+++ b/components/polylith/poetry/commands/check.py
@@ -4,7 +4,7 @@ from typing import Set, Union
 from cleo.helpers import option
 from poetry.console.commands.command import Command
 from poetry.factory import Factory
-from polylith import check, info, project, repo, workspace
+from polylith import alias, check, info, project, repo, workspace
 
 
 class CheckCommand(Command):
@@ -16,6 +16,12 @@ class CheckCommand(Command):
             long_name="strict",
             description="More strict checks when matching name of third-party libraries and imports",
             flag=True,
+        ),
+        option(
+            long_name="alias",
+            description="alias for a third-party library, useful when an import differ from the library name",
+            flag=False,
+            multiple=True,
         ),
     ]
 
@@ -41,10 +47,15 @@ class CheckCommand(Command):
             collected_imports = check.report.collect_all_imports(root, ns, project_data)
             third_party_libs = self.find_third_party_libs(path)
 
+            library_aliases = alias.parse(self.option("alias"))
+            extra = alias.pick(library_aliases, third_party_libs)
+
+            libs = third_party_libs.union(extra)
+
             details = check.report.create_report(
                 project_data,
                 collected_imports,
-                third_party_libs,
+                libs,
                 is_strict,
             )
 

--- a/components/polylith/poetry/commands/libs.py
+++ b/components/polylith/poetry/commands/libs.py
@@ -4,7 +4,7 @@ from typing import Set, Union
 from cleo.helpers import option
 from poetry.console.commands.command import Command
 from poetry.factory import Factory
-from polylith import info, project, repo, workspace
+from polylith import alias, info, project, repo, workspace
 from polylith.libs import report
 
 
@@ -17,6 +17,12 @@ class LibsCommand(Command):
             long_name="strict",
             description="More strict checks when matching name of third-party libraries and imports",
             flag=True,
+        ),
+        option(
+            long_name="alias",
+            description="alias for a third-party library, useful when an import differ from the library name",
+            flag=False,
+            multiple=True,
         ),
     ]
 
@@ -44,9 +50,14 @@ class LibsCommand(Command):
         try:
             third_party_libs = self.find_third_party_libs(path)
 
+            library_aliases = alias.parse(self.option("alias"))
+            extra = alias.pick(library_aliases, third_party_libs)
+
+            libs = third_party_libs.union(extra)
+
             return report.print_missing_installed_libs(
                 brick_imports,
-                third_party_libs,
+                libs,
                 name,
                 is_strict,
             )

--- a/components/polylith/poetry/commands/libs.py
+++ b/components/polylith/poetry/commands/libs.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 from poetry.console.commands.command import Command
 from polylith import alias, info, project, repo, workspace
-from polylith.commands.create import command_options, find_third_party_libs
 from polylith.libs import report
+from polylith.poetry.commands.check import command_options, find_third_party_libs
 
 
 class LibsCommand(Command):

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.8.3"
+version = "1.9.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -25,7 +25,8 @@ packages = [
     {include = "polylith/reporting",from = "../../components"},
     {include = "polylith/sync",from = "../../components"},
     {include = "polylith/test",from = "../../components"},
-    {include = "polylith/workspace",from = "../../components"}
+    {include = "polylith/workspace",from = "../../components"},
+    {include = "polylith/alias",from = "../../components"},
 ]
 
 [tool.poetry.plugins."poetry.application.plugin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ packages = [
     {include = "polylith/sync",from = "components"},
     {include = "polylith/test",from = "components"},
     {include = "polylith/workspace",from = "components"},
-    {include = "development"}
+    {include = "polylith/alias",from = "components"},
+    {include = "development"},
 ]
 
 [tool.poetry.dependencies]

--- a/test/components/polylith/alias/test_alias.py
+++ b/test/components/polylith/alias/test_alias.py
@@ -1,0 +1,54 @@
+from polylith import alias
+
+
+def test_parse_one_key_one_value_alias():
+    res = alias.parse(["opencv-python=cv2"])
+
+    assert res["opencv-python"] == ["cv2"]
+    assert len(res.keys()) == 1
+
+
+def test_parse_one_key_many_values_alias():
+    res = alias.parse(["matplotlib=matplotlib, mpl_toolkits"])
+
+    assert res["matplotlib"] == ["matplotlib", "mpl_toolkits"]
+    assert len(res.keys()) == 1
+
+
+def test_parse_many_keys_many_values_alias():
+    res = alias.parse(["matplotlib=matplotlib, mpl_toolkits", "opencv-python=cv2"])
+
+    assert res["matplotlib"] == ["matplotlib", "mpl_toolkits"]
+    assert res["opencv-python"] == ["cv2"]
+
+    assert len(res.keys()) == 2
+
+
+def test_pick_alias_by_key():
+    aliases = {"opencv-python": ["cv2"]}
+
+    keys = {"one", "two", "opencv-python", "three"}
+
+    res = alias.pick(aliases, keys)
+
+    assert res == {"cv2"}
+
+
+def test_pick_aliases_by_keys():
+    aliases = {"opencv-python": ["cv2"], "matplotlib": ["mpl_toolkits", "matplotlib"]}
+
+    keys = {"one", "two", "opencv-python", "matplotlib", "three"}
+
+    res = alias.pick(aliases, keys)
+
+    assert res == {"cv2", "mpl_toolkits", "matplotlib"}
+
+
+def test_pick_empty_alias_by_keys():
+    aliases = {}
+
+    keys = {"one", "two", "opencv-python", "matplotlib", "three"}
+
+    res = alias.pick(aliases, keys)
+
+    assert res == set()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Useful when an import differ from the library name, such as:
library name "opencv-python" and the actual import is "cv2". This will cause the `poly check` and `poly libs` to report missing dependencies.

The `--alias` option will help the commands with understanding the imports.

Example usage:

```bash
poetry poly check --alias opencv-python=cv2
```

With several aliases:

```bash
poetry poly check --alias opencv-python=cv2 --alias matplotlib=mpl_toolkit
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Partially solves #107 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local install and testing with the python-polylith-example repo.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
