### PR TITLE
refactor(poly check, poly libs): extract poetry internals

### DIFF
--- a/components/polylith/poetry/__init__.py
+++ b/components/polylith/poetry/__init__.py
@@ -1,0 +1,3 @@
+from polylith.poetry import commands, internals
+
+__all__ = ["commands", "internals"]

--- a/components/polylith/poetry/commands/check.py
+++ b/components/polylith/poetry/commands/check.py
@@ -1,13 +1,9 @@
-from collections import defaultdict
 from pathlib import Path
-from typing import DefaultDict, List, Set, Union
 
 from cleo.helpers import option
 from poetry.console.commands.command import Command
-from poetry.factory import Factory
-from poetry.poetry import Poetry
-from poetry.utils.env import EnvManager
 from polylith import alias, check, info, project, repo, workspace
+from polylith.poetry.internals import find_third_party_libs, packages_distributions
 
 command_options = [
     option(
@@ -22,31 +18,6 @@ command_options = [
         multiple=True,
     ),
 ]
-
-
-def packages_distributions(
-    poetry: Poetry, path: Union[Path, None]
-) -> DefaultDict[str, List[str]]:
-    project_poetry = Factory().create_poetry(path) if path else poetry
-
-    env = EnvManager(project_poetry).get()
-    pkg_to_dist = defaultdict(list)
-    for dist in env.site_packages.distributions():
-        for pkg in (dist.read_text("top_level.txt") or "").split():
-            pkg_to_dist[dist.metadata["Name"]].append(pkg)
-
-    return pkg_to_dist
-
-
-def find_third_party_libs(poetry: Poetry, path: Union[Path, None]) -> Set:
-    project_poetry = Factory().create_poetry(path) if path else poetry
-
-    if not project_poetry.locker.is_locked():
-        raise ValueError("poetry.lock not found. Run `poetry lock` to create it.")
-
-    packages = project_poetry.locker.locked_repository().packages
-
-    return {p.name for p in packages}
 
 
 class CheckCommand(Command):

--- a/components/polylith/poetry/commands/check.py
+++ b/components/polylith/poetry/commands/check.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from cleo.helpers import option
 from poetry.console.commands.command import Command
 from polylith import alias, check, info, project, repo, workspace
-from polylith.poetry.internals import find_third_party_libs, packages_distributions
+from polylith.poetry import internals
 
 command_options = [
     option(
@@ -36,9 +36,10 @@ class CheckCommand(Command):
 
         try:
             collected_imports = check.report.collect_all_imports(root, ns, project_data)
-            third_party_libs = find_third_party_libs(self.poetry, path)
+            third_party_libs = internals.find_third_party_libs(self.poetry, path)
 
-            known_aliases = packages_distributions(self.poetry, path)
+            dists = internals.distributions(self.poetry, path)
+            known_aliases = internals.distributions_packages(dists)
             known_aliases.update(alias.parse(self.option("alias")))
 
             extra = alias.pick(known_aliases, third_party_libs)

--- a/components/polylith/poetry/commands/libs.py
+++ b/components/polylith/poetry/commands/libs.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from poetry.console.commands.command import Command
 from polylith import alias, info, project, repo, workspace
 from polylith.libs import report
-from polylith.poetry.commands.check import command_options, find_third_party_libs
+from polylith.poetry.commands.check import command_options
+from polylith.poetry.internals import find_third_party_libs
 
 
 class LibsCommand(Command):

--- a/components/polylith/poetry/internals.py
+++ b/components/polylith/poetry/internals.py
@@ -29,15 +29,20 @@ def distributions_packages(dists) -> Dict[str, List[str]]:
     return reduce(map_packages, dists, {})
 
 
+def get_project_poetry(poetry: Poetry, path: Union[Path, None]) -> Poetry:
+    return Factory().create_poetry(path) if path else poetry
+
+
 def distributions(poetry: Poetry, path: Union[Path, None]) -> Iterable:
-    project_poetry = Factory().create_poetry(path) if path else poetry
+    project_poetry = get_project_poetry(poetry, path)
+
     env = EnvManager(project_poetry).get()
 
     return env.site_packages.distributions()
 
 
 def find_third_party_libs(poetry: Poetry, path: Union[Path, None]) -> Set:
-    project_poetry = Factory().create_poetry(path) if path else poetry
+    project_poetry = get_project_poetry(poetry, path)
 
     if not project_poetry.locker.is_locked():
         raise ValueError("poetry.lock not found. Run `poetry lock` to create it.")

--- a/components/polylith/poetry/internals.py
+++ b/components/polylith/poetry/internals.py
@@ -1,7 +1,6 @@
-from collections import defaultdict
 from functools import reduce
 from pathlib import Path
-from typing import DefaultDict, Dict, Iterable, List, Set, Union
+from typing import Dict, Iterable, List, Set, Union
 
 from poetry.factory import Factory
 from poetry.poetry import Poetry
@@ -35,20 +34,6 @@ def distributions(poetry: Poetry, path: Union[Path, None]) -> Iterable:
     env = EnvManager(project_poetry).get()
 
     return env.site_packages.distributions()
-
-
-def packages_distributions(
-    poetry: Poetry, path: Union[Path, None]
-) -> DefaultDict[str, List[str]]:
-    project_poetry = Factory().create_poetry(path) if path else poetry
-
-    env = EnvManager(project_poetry).get()
-    pkg_to_dist = defaultdict(list)
-    for dist in env.site_packages.distributions():
-        for pkg in (dist.read_text("top_level.txt") or "").split():
-            pkg_to_dist[dist.metadata["Name"]].append(pkg)
-
-    return pkg_to_dist
 
 
 def find_third_party_libs(poetry: Poetry, path: Union[Path, None]) -> Set:

--- a/components/polylith/poetry/internals.py
+++ b/components/polylith/poetry/internals.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from functools import reduce
 from pathlib import Path
-from typing import DefaultDict, Dict, List, Set, Union
+from typing import DefaultDict, Dict, Iterable, List, Set, Union
 
 from poetry.factory import Factory
 from poetry.poetry import Poetry
@@ -18,7 +18,7 @@ def mapped_packages(dist) -> dict:
     packages = top_level_packages(dist)
     name = dist.metadata["name"]
 
-    return {name: package for package in packages}
+    return {name: packages} if packages else {}
 
 
 def map_packages(acc, dist) -> dict:
@@ -30,7 +30,7 @@ def distributions_packages(dists) -> Dict[str, List[str]]:
     return reduce(map_packages, dists, {})
 
 
-def distributions(poetry: Poetry, path: Union[Path, None]):
+def distributions(poetry: Poetry, path: Union[Path, None]) -> Iterable:
     project_poetry = Factory().create_poetry(path) if path else poetry
     env = EnvManager(project_poetry).get()
 

--- a/components/polylith/poetry/internals.py
+++ b/components/polylith/poetry/internals.py
@@ -1,0 +1,62 @@
+from collections import defaultdict
+from functools import reduce
+from pathlib import Path
+from typing import DefaultDict, Dict, List, Set, Union
+
+from poetry.factory import Factory
+from poetry.poetry import Poetry
+from poetry.utils.env import EnvManager
+
+
+def top_level_packages(dist) -> List[str]:
+    top_level = dist.read_text("top_level.txt")
+
+    return str.split(top_level or "")
+
+
+def mapped_packages(dist) -> dict:
+    packages = top_level_packages(dist)
+    name = dist.metadata["name"]
+
+    return {name: package for package in packages}
+
+
+def map_packages(acc, dist) -> dict:
+    return {**acc, **mapped_packages(dist)}
+
+
+def distributions_packages(dists) -> Dict[str, List[str]]:
+    """Return a mapping of top-level packages to their distributions."""
+    return reduce(map_packages, dists, {})
+
+
+def distributions(poetry: Poetry, path: Union[Path, None]):
+    project_poetry = Factory().create_poetry(path) if path else poetry
+    env = EnvManager(project_poetry).get()
+
+    return env.site_packages.distributions()
+
+
+def packages_distributions(
+    poetry: Poetry, path: Union[Path, None]
+) -> DefaultDict[str, List[str]]:
+    project_poetry = Factory().create_poetry(path) if path else poetry
+
+    env = EnvManager(project_poetry).get()
+    pkg_to_dist = defaultdict(list)
+    for dist in env.site_packages.distributions():
+        for pkg in (dist.read_text("top_level.txt") or "").split():
+            pkg_to_dist[dist.metadata["Name"]].append(pkg)
+
+    return pkg_to_dist
+
+
+def find_third_party_libs(poetry: Poetry, path: Union[Path, None]) -> Set:
+    project_poetry = Factory().create_poetry(path) if path else poetry
+
+    if not project_poetry.locker.is_locked():
+        raise ValueError("poetry.lock not found. Run `poetry lock` to create it.")
+
+    packages = project_poetry.locker.locked_repository().packages
+
+    return {p.name for p in packages}

--- a/test/components/polylith/poetry/test_internals.py
+++ b/test/components/polylith/poetry/test_internals.py
@@ -1,0 +1,59 @@
+"""
+Using the dependencies of the development virtual environment
+to assert the Poetry internals itself,
+and catch any breaking features in upcoming versions.
+"""
+
+from pathlib import Path
+
+from poetry.factory import Factory
+from polylith.poetry import internals
+
+
+def test_find_third_party_libs():
+    path = Path.cwd()
+
+    dev_poetry = Factory().create_poetry(path)
+
+    res = internals.find_third_party_libs(dev_poetry, path)
+
+    expected = {"rich", "isort", "black"}
+
+    assert expected.issubset(res)
+
+
+def test_distributions():
+    path = Path.cwd()
+
+    dev_poetry = Factory().create_poetry(path)
+
+    res = internals.distributions(dev_poetry, path)
+
+    assert res is not None and len(list(res))
+
+
+def test_distribution_packages():
+    path = Path.cwd()
+
+    dev_poetry = Factory().create_poetry(path)
+
+    res = internals.packages_distributions(dev_poetry, path)
+
+    expected_dist = "importlib-metadata"
+    expected_package = "importlib_metadata"
+
+    assert res.get(expected_dist) is not None
+    assert res[expected_dist] == [expected_package]
+
+
+def test_distributions_packages_alt_implementation():
+    path = Path.cwd()
+
+    dev_poetry = Factory().create_poetry(path)
+
+    dists = internals.distributions(dev_poetry, path)
+
+    first = internals.distributions_packages(dists)
+    second = internals.packages_distributions(dev_poetry, path)
+
+    assert first == second

--- a/test/components/polylith/poetry/test_internals.py
+++ b/test/components/polylith/poetry/test_internals.py
@@ -36,24 +36,12 @@ def test_distribution_packages():
     path = Path.cwd()
 
     dev_poetry = Factory().create_poetry(path)
+    dists = internals.distributions(dev_poetry, path)
 
-    res = internals.packages_distributions(dev_poetry, path)
+    res = internals.distributions_packages(dists)
 
     expected_dist = "importlib-metadata"
     expected_package = "importlib_metadata"
 
     assert res.get(expected_dist) is not None
     assert res[expected_dist] == [expected_package]
-
-
-def test_distributions_packages_alt_implementation():
-    path = Path.cwd()
-
-    dev_poetry = Factory().create_poetry(path)
-
-    dists = internals.distributions(dev_poetry, path)
-
-    first = internals.distributions_packages(dists)
-    second = internals.packages_distributions(dev_poetry, path)
-
-    assert first == second


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Extract the `poetry` specific internals - the usage of `EnvManager` and the `locker` -  into a separate module.

This is a continuation of #115 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Refactoring and adding unit tests asserting the functionality is there also in future Poetry versions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactoring (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
