### PR TITLE
feat(poly diff): multiple diff tag patterns

### DIFF
--- a/components/polylith/diff/collect.py
+++ b/components/polylith/diff/collect.py
@@ -41,8 +41,8 @@ def get_changed_projects(changed_files: List[Path]) -> list:
     return sorted(filtered)
 
 
-def get_latest_tag(root: Path) -> Union[str, None]:
-    tag_pattern = workspace.parser.get_git_tag_pattern_from_config(root)
+def get_latest_tag(root: Path, key: Union[str, None]) -> Union[str, None]:
+    tag_pattern = workspace.parser.get_tag_pattern_from_config(root, key)
 
     res = subprocess.run(
         ["git", "tag", "-l", "--sort=-committerdate", f"{tag_pattern}"],

--- a/components/polylith/poetry/commands/diff.py
+++ b/components/polylith/poetry/commands/diff.py
@@ -22,6 +22,11 @@ class DiffCommand(Command):
             description="Print changed bricks",
             flag=True,
         ),
+        option(
+            long_name="since",
+            description="Changed since a specific tag",
+            flag=False,
+        ),
     ]
 
     def has_partial_options(self) -> bool:
@@ -69,7 +74,9 @@ class DiffCommand(Command):
 
     def handle(self) -> int:
         root = repo.get_workspace_root(Path.cwd())
-        tag = diff.collect.get_latest_tag(root)
+
+        tag_name = self.option("since")
+        tag = diff.collect.get_latest_tag(root, tag_name)
 
         if not tag:
             self.line("No tags found in repository.")

--- a/components/polylith/workspace/create.py
+++ b/components/polylith/workspace/create.py
@@ -13,6 +13,10 @@ git_tag_pattern = "stable-*"
 [tool.polylith.structure]
 theme = "{theme}"
 
+[tool.polylith.tag.patterns]
+stable = "stable-*"
+release = "v[0-9]*"
+
 [tool.polylith.resources]
 brick_docs_enabled = false
 

--- a/components/polylith/workspace/parser.py
+++ b/components/polylith/workspace/parser.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from pathlib import Path
+from typing import Union
 
 import tomlkit
 from polylith import repo
@@ -20,10 +21,17 @@ def get_namespace_from_config(path: Path) -> str:
     return toml["tool"]["polylith"]["namespace"]
 
 
-def get_git_tag_pattern_from_config(path: Path) -> str:
+def get_git_tag_pattern(toml: dict) -> str:
+    """Fallback git tag pattern configuration"""
+    return toml["tool"]["polylith"]["git_tag_pattern"]
+
+
+def get_tag_pattern_from_config(path: Path, key: Union[str, None]) -> str:
     toml: dict = _load_workspace_config(path)
 
-    return toml["tool"]["polylith"]["git_tag_pattern"]
+    patterns = toml["tool"]["polylith"].get("tag", {}).get("patterns")
+
+    return patterns[key or "stable"] if patterns else get_git_tag_pattern(toml)
 
 
 def is_test_generation_enabled(path: Path) -> bool:

--- a/development/david.py
+++ b/development/david.py
@@ -25,7 +25,7 @@ print(repo.projects_dir)
 root = Path.cwd()
 ns = workspace.parser.get_namespace_from_config(root)
 
-tag = diff.collect.get_latest_tag(root) or ""
+tag = diff.collect.get_latest_tag(root, "release") or ""
 
 changed_files = diff.collect.get_files(tag)
 changed_components = diff.collect.get_changed_components(changed_files, ns)

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.11.0"
+version = "1.12.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/workspace.toml
+++ b/workspace.toml
@@ -1,9 +1,12 @@
 [tool.polylith]
 namespace = "polylith"
-git_tag_pattern = "v*"
 
 [tool.polylith.structure]
 theme = "loose"
+
+[tool.polylith.tag.patterns]
+stable = "stable-*"
+release = "v[0-9]*"
 
 [tool.polylith.test]
 enabled = false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add possibility to have more than one git tag pattern, such as `stable` and `release`.

fixes #130 

TOML docs about Table structure: https://toml.io/en/v1.0.0#table
Clojure example: https://github.com/polyfy/polylith/blob/master/workspace.edn
Clojure docs: https://polylith.gitbook.io/poly/workflow/tagging

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will make it possible to calculate differences in a more fine-grained way.

Example:
the diff between a feature branch and the latest stable version (usually the main branch),
or the diff based on a release version.

usage: 
```shell
# using the default "stable" in the new workspace.toml table, or the already existing "git_tag_pattern"
poetry poly diff
```

```shell
# calculate diff based on the latest release tag. The pattern is defined in workspace.toml
poetry poly diff --since release
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local install, tested on this repo + the python polylith example repo.
CI ✅ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
