### PR TITLE
fix(cli): gather sub-dependencies when runnint the poly check command

### DIFF
--- a/components/polylith/commands/check.py
+++ b/components/polylith/commands/check.py
@@ -19,6 +19,13 @@ def run(root: Path, ns: str, project_data: dict, options: dict) -> bool:
     known_aliases = distributions.distributions_packages(dists)
     known_aliases.update(alias.parse(library_alias))
 
+    """
+    WIP:
+    dist_packages = distributions.distributions_packages(dists)
+    sub_packages = distributions.distributions_sub_packages(dists)
+    custom_aliases = alias.parse(library_alias)
+    """
+
     extra = alias.pick(known_aliases, third_party_libs)
 
     libs = third_party_libs.union(extra)

--- a/components/polylith/commands/check.py
+++ b/components/polylith/commands/check.py
@@ -14,7 +14,7 @@ def run(root: Path, ns: str, project_data: dict, options: dict) -> bool:
     name = project_data["name"]
 
     collected_imports = check.report.collect_all_imports(root, ns, project_data)
-    dists = importlib.metadata.distributions()
+    dists = list(importlib.metadata.distributions())
 
     known_aliases = distributions.distributions_packages(dists)
     known_aliases.update(alias.parse(library_alias))

--- a/components/polylith/commands/check.py
+++ b/components/polylith/commands/check.py
@@ -1,39 +1,42 @@
 import importlib.metadata
 from pathlib import Path
-
+from typing import Set
 from polylith import alias, check, distributions
+
+
+def collect_known_aliases_and_sub_dependencies(
+    project_data: dict, options: dict
+) -> Set[str]:
+    third_party_libs = project_data["deps"]
+    library_alias = options["alias"]
+
+    dists = list(importlib.metadata.distributions())
+
+    dist_packages = distributions.distributions_packages(dists)
+    sub_packages = distributions.distributions_sub_packages(dists)
+    custom_aliases = alias.parse(library_alias)
+
+    a = alias.pick(dist_packages, third_party_libs)
+    b = alias.pick(sub_packages, third_party_libs)
+    c = alias.pick(custom_aliases, third_party_libs)
+
+    return third_party_libs.union(a, b, c)
 
 
 def run(root: Path, ns: str, project_data: dict, options: dict) -> bool:
     is_verbose = options["verbose"]
     is_quiet = options["quiet"]
     is_strict = options["strict"]
-    library_alias = options["alias"]
 
-    third_party_libs = project_data["deps"]
     name = project_data["name"]
 
     collected_imports = check.report.collect_all_imports(root, ns, project_data)
-    dists = list(importlib.metadata.distributions())
-
-    known_aliases = distributions.distributions_packages(dists)
-    known_aliases.update(alias.parse(library_alias))
-
-    """
-    WIP:
-    dist_packages = distributions.distributions_packages(dists)
-    sub_packages = distributions.distributions_sub_packages(dists)
-    custom_aliases = alias.parse(library_alias)
-    """
-
-    extra = alias.pick(known_aliases, third_party_libs)
-
-    libs = third_party_libs.union(extra)
+    collected_libs = collect_known_aliases_and_sub_dependencies(project_data, options)
 
     details = check.report.create_report(
         project_data,
         collected_imports,
-        libs,
+        collected_libs,
         is_strict,
     )
 

--- a/components/polylith/distributions/__init__.py
+++ b/components/polylith/distributions/__init__.py
@@ -1,3 +1,7 @@
-from polylith.distributions.core import distributions_packages, get_distributions
+from polylith.distributions.core import (
+    distributions_packages,
+    distributions_sub_packages,
+    get_distributions,
+)
 
-__all__ = ["distributions_packages", "get_distributions"]
+__all__ = ["distributions_packages", "distributions_sub_packages", "get_distributions"]

--- a/components/polylith/distributions/core.py
+++ b/components/polylith/distributions/core.py
@@ -45,7 +45,7 @@ def distributions_subpackages(dists) -> Set[str]:
 def distributions_packages(dists) -> Dict[str, List[str]]:
     """Return a mapping of top-level packages to their distributions.
 
-    Additional dist sub-dependency package names are appended to the result.
+    Additional dist sub-dependency package names (without dist names) are appended to the result.
     """
     mapped: dict = reduce(map_packages, dists, {})
 

--- a/components/polylith/distributions/core.py
+++ b/components/polylith/distributions/core.py
@@ -17,9 +17,9 @@ def dist_subpackages(dist) -> dict:
     name = dist.metadata["name"]
     dependencies = importlib.metadata.requires(name) or []
 
-    parsed_package_names = {parse_sub_package_name(d) for d in dependencies}
+    parsed_package_names = list({parse_sub_package_name(d) for d in dependencies})
 
-    return {name: parsed_package_names}
+    return {name: parsed_package_names} if dependencies else {}
 
 
 def map_sub_packages(acc, dist) -> dict:

--- a/projects/polylith-cli/pyproject.toml
+++ b/projects/polylith-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/commands/test_check.py
+++ b/test/components/polylith/commands/test_check.py
@@ -1,0 +1,12 @@
+from polylith.commands import check
+
+
+def test_collect_known_aliases_and_sub_dependencies():
+    fake_project_data = {"deps": {"typer", "hello-world-library"}}
+    fake_options = {"alias": ["hello-world-library=hello"]}
+
+    res = check.collect_known_aliases_and_sub_dependencies(fake_project_data, fake_options)
+
+    assert "typer" in res
+    assert "typing-extensions" in res
+    assert "hello" in res

--- a/test/components/polylith/commands/test_info.py
+++ b/test/components/polylith/commands/test_info.py
@@ -1,5 +1,0 @@
-from polylith.commands import info
-
-
-def test_sample():
-    assert info is not None

--- a/test/components/polylith/distributions/test_core.py
+++ b/test/components/polylith/distributions/test_core.py
@@ -16,13 +16,27 @@ def test_distribution_packages():
 
 
 def test_parse_package_name_from_dist_requires():
-    assert "greenlet" == distributions.core.only_package_name("greenlet !=0.4.17")
-    assert "mysqlclient" == distributions.core.only_package_name(
-        "mysqlclient >=1.4.0 ; extra == 'mysql'"
-    )
-    assert "typing-extensions" == distributions.core.only_package_name(
-        "typing-extensions>=4.6.0)"
-    )
-    assert "pymysql" == distributions.core.only_package_name(
-        "pymysql ; extra == 'pymysql'"
-    )
+    expected = {
+        "greenlet": "greenlet !=0.4.17",
+        "mysqlclient": "mysqlclient >=1.4.0 ; extra == 'mysql'",
+        "typing-extensions": "typing-extensions>=4.6.0",
+        "pymysql": "pymysql ; extra == 'pymysql'",
+        "one": "one<=0.4.17",
+        "two": "two^=0.4.17",
+        "three": "three~=0.4.17",
+    }
+
+    for k, v in expected.items():
+        assert k == distributions.core.parse_sub_package_name(v)
+
+
+def test_distribution_sub_packages():
+    dists = list(importlib.metadata.distributions())
+
+    res = distributions.distributions_sub_packages(dists)
+
+    expected_dist = "typer"
+    expected_sub_package = "typing-extensions"
+
+    assert res.get(expected_dist) is not None
+    assert expected_sub_package in res[expected_dist]

--- a/test/components/polylith/distributions/test_core.py
+++ b/test/components/polylith/distributions/test_core.py
@@ -4,7 +4,7 @@ from polylith import distributions
 
 
 def test_distribution_packages():
-    dists = importlib.metadata.distributions()
+    dists = list(importlib.metadata.distributions())
 
     res = distributions.distributions_packages(dists)
 
@@ -13,3 +13,16 @@ def test_distribution_packages():
 
     assert res.get(expected_dist) is not None
     assert res[expected_dist] == [expected_package]
+
+
+def test_parse_package_name_from_dist_requires():
+    assert "greenlet" == distributions.core.only_package_name("greenlet !=0.4.17")
+    assert "mysqlclient" == distributions.core.only_package_name(
+        "mysqlclient >=1.4.0 ; extra == 'mysql'"
+    )
+    assert "typing-extensions" == distributions.core.only_package_name(
+        "typing-extensions>=4.6.0)"
+    )
+    assert "pymysql" == distributions.core.only_package_name(
+        "pymysql ; extra == 'pymysql'"
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Gather sub dependencies when running `poly check` from the CLI. This, to allow imports from library sub dependencies in source code.

Example: fastAPI and using Pydantic models should be allowed. Same with Typer and the typing-extensions sub dependency.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Making the `poly check` command behave more correct when analyzing third-party dependencies.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Local running manual tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
