### PR TITLE
fix(poly check, poly libs): collect known aliases, with sub-dependencies when not from lock-file

### DIFF
--- a/components/polylith/commands/check.py
+++ b/components/polylith/commands/check.py
@@ -1,26 +1,14 @@
-import importlib.metadata
 from pathlib import Path
 from typing import Set
-from polylith import alias, check, distributions
+
+from polylith import check, distributions
 
 
-def collect_known_aliases_and_sub_dependencies(
-    project_data: dict, options: dict
-) -> Set[str]:
-    third_party_libs = project_data["deps"]
+def collect_known_aliases(project_data: dict, options: dict) -> Set[str]:
+    deps = project_data["deps"]
     library_alias = options["alias"]
 
-    dists = list(importlib.metadata.distributions())
-
-    dist_packages = distributions.distributions_packages(dists)
-    sub_packages = distributions.distributions_sub_packages(dists)
-    custom_aliases = alias.parse(library_alias)
-
-    a = alias.pick(dist_packages, third_party_libs)
-    b = alias.pick(sub_packages, third_party_libs)
-    c = alias.pick(custom_aliases, third_party_libs)
-
-    return third_party_libs.union(a, b, c)
+    return distributions.known_aliases_and_sub_dependencies(deps, library_alias)
 
 
 def run(root: Path, ns: str, project_data: dict, options: dict) -> bool:
@@ -31,7 +19,7 @@ def run(root: Path, ns: str, project_data: dict, options: dict) -> bool:
     name = project_data["name"]
 
     collected_imports = check.report.collect_all_imports(root, ns, project_data)
-    collected_libs = collect_known_aliases_and_sub_dependencies(project_data, options)
+    collected_libs = collect_known_aliases(project_data, options)
 
     details = check.report.create_report(
         project_data,

--- a/components/polylith/commands/libs.py
+++ b/components/polylith/commands/libs.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from polylith import alias
+from polylith import distributions
 from polylith.libs import report
 
 
@@ -9,17 +9,14 @@ def run(root: Path, ns: str, project_data: dict, options: dict) -> bool:
     library_alias = options["alias"]
 
     name = project_data["name"]
-    third_party_libs = project_data["deps"]
+    deps = project_data["deps"]
 
     brick_imports = report.get_third_party_imports(root, ns, project_data)
 
     report.print_libs_summary(brick_imports, project_data)
     report.print_libs_in_bricks(brick_imports)
 
-    library_aliases = alias.parse(library_alias)
-    extra = alias.pick(library_aliases, third_party_libs)
-
-    libs = third_party_libs.union(extra)
+    libs = distributions.known_aliases_and_sub_dependencies(deps, library_alias)
 
     return report.print_missing_installed_libs(
         brick_imports,

--- a/components/polylith/distributions/__init__.py
+++ b/components/polylith/distributions/__init__.py
@@ -1,7 +1,13 @@
+from polylith.distributions.collect import known_aliases_and_sub_dependencies
 from polylith.distributions.core import (
     distributions_packages,
     distributions_sub_packages,
     get_distributions,
 )
 
-__all__ = ["distributions_packages", "distributions_sub_packages", "get_distributions"]
+__all__ = [
+    "distributions_packages",
+    "distributions_sub_packages",
+    "get_distributions",
+    "known_aliases_and_sub_dependencies",
+]

--- a/components/polylith/distributions/collect.py
+++ b/components/polylith/distributions/collect.py
@@ -1,0 +1,33 @@
+import importlib.metadata
+from typing import Set
+
+from polylith import alias
+from polylith.distributions.core import (
+    distributions_packages,
+    distributions_sub_packages,
+)
+
+
+def known_aliases_and_sub_dependencies(
+    deps: dict, library_alias: list
+) -> Set[str]:
+    """Collect known aliases (packages) for third-party libraries.
+
+    When the library origin is not from a lock-file:
+    collect sub-dependencies for each library, and append to the result.
+    """
+
+    third_party_libs = deps["items"]
+    lock_file = str.endswith(deps["source"], ".lock")
+
+    dists = list(importlib.metadata.distributions())
+
+    dist_packages = distributions_packages(dists)
+    custom_aliases = alias.parse(library_alias)
+    sub_deps = distributions_sub_packages(dists) if not lock_file else {}
+
+    a = alias.pick(dist_packages, third_party_libs)
+    b = alias.pick(custom_aliases, third_party_libs)
+    c = alias.pick(sub_deps, third_party_libs)
+
+    return third_party_libs.union(a, b, c)

--- a/components/polylith/poetry/commands/check.py
+++ b/components/polylith/poetry/commands/check.py
@@ -39,7 +39,10 @@ class CheckCommand(Command):
 
         try:
             third_party_libs = internals.find_third_party_libs(self.poetry, path)
-            merged = {**project_data, **{"deps": third_party_libs}}
+            merged = {
+                **project_data,
+                **{"deps": {"items": third_party_libs, "source": "poetry.lock"}},
+            }
 
             return commands.check.run(root, ns, merged, options)
         except ValueError as e:

--- a/components/polylith/poetry/commands/libs.py
+++ b/components/polylith/poetry/commands/libs.py
@@ -20,7 +20,10 @@ class LibsCommand(Command):
 
         try:
             third_party_libs = find_third_party_libs(self.poetry, path)
-            merged = {**data, **{"deps": third_party_libs}}
+            merged = {
+                **data,
+                **{"deps": {"items": third_party_libs, "source": "poetry.lock"}},
+            }
 
             return commands.libs.run(root, ns, merged, options)
         except ValueError as e:

--- a/components/polylith/project/get.py
+++ b/components/polylith/project/get.py
@@ -1,7 +1,7 @@
 import re
 from functools import lru_cache
 from pathlib import Path
-from typing import List, Set
+from typing import List
 
 import tomlkit
 from polylith import repo, workspace
@@ -32,15 +32,17 @@ def get_project_name(data) -> str:
     return data["tool"]["poetry"]["name"]
 
 
-def get_project_dependencies(data) -> Set:
+def get_project_dependencies(data) -> dict:
     if repo.is_poetry(data):
         deps = data["tool"]["poetry"].get("dependencies", [])
 
-        return set(deps.keys())
+        items = set(deps.keys())
     else:
         deps = data["project"].get("dependencies", [])
 
-        return {re.split(r"[\^~=!<>]", dep)[0] for dep in deps}
+        items = {re.split(r"[\^~=!<>]", dep)[0] for dep in deps}
+
+    return {"items": items, "source": repo.default_toml}
 
 
 @lru_cache

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.14.0"
+version = "1.14.1"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/commands/test_check.py
+++ b/test/components/polylith/commands/test_check.py
@@ -2,10 +2,12 @@ from polylith.commands import check
 
 
 def test_collect_known_aliases_and_sub_dependencies():
-    fake_project_data = {"deps": {"typer", "hello-world-library"}}
+    fake_project_data = {
+        "deps": {"items": {"typer", "hello-world-library"}, "source": "unit-test"}
+    }
     fake_options = {"alias": ["hello-world-library=hello"]}
 
-    res = check.collect_known_aliases_and_sub_dependencies(fake_project_data, fake_options)
+    res = check.collect_known_aliases(fake_project_data, fake_options)
 
     assert "typer" in res
     assert "typing-extensions" in res


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fix(cli): `poly libs` to collect sub-dependencies, as done in `poly check`.

Also, handling the collecting differently depending on if the source/origins is from a lock-file or not.
When gathering dependencies form a lock file: sub dependencies are already there.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To output more correct result for `poly libs` and the CLI.

Also, not extracting sub-dependencies when running in a `Poetry` context.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ run local CLI commands
✅ Local plugin install and run commands

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
