### PR TITLE
fix(hatch): lookup bricks in another TOML section

### DIFF
--- a/components/polylith/project/get.py
+++ b/components/polylith/project/get.py
@@ -25,7 +25,8 @@ def find_by_key(data: dict, key: str) -> Any:
 
 
 def get_hatch_project_packages(data) -> dict:
-    build_data = data["tool"]["hatch"].get("build", {})
+    hatch_data = data["tool"]["hatch"]
+    build_data = hatch_data.get("build", {}) if isinstance(hatch_data, dict) else {}
 
     force_included = build_data.get("force-include")
 
@@ -33,8 +34,9 @@ def get_hatch_project_packages(data) -> dict:
         return force_included
 
     found = find_by_key(build_data, "polylith")
+    bricks = found.get("bricks", {}) if isinstance(found, dict) else {}
 
-    return found.get("bricks", {}) if isinstance(found, dict) else {}
+    return bricks if isinstance(bricks, dict) else {}
 
 
 def get_project_package_includes(namespace: str, data) -> List[dict]:

--- a/test/components/polylith/project/test_project_get.py
+++ b/test/components/polylith/project/test_project_get.py
@@ -6,10 +6,10 @@ namespace = "unittest"
 poetry_toml = """\
 [tool.poetry]
 packages = [
-    {include = "unittest/one",from = "../../components"}
+    {include = "unittest/one",from = "../../bases"},
+    {include = "unittest/two",from = "../../components"}
 ]
 """
-
 
 hatch_toml = """\
 [tool.hatch.build.force-include]
@@ -17,21 +17,54 @@ hatch_toml = """\
 "../../components/unittest/two" = "unittest/two"
 """
 
+hatch_toml_alternative = """\
+[tool.hatch.build.hooks.targets.wheel.polylith.bricks]
+"../../bases/unittest/one" = "unittest/one"
+"../../components/unittest/two" = "unittest/two"
+"""
+
+hatch_toml_combined = """\
+[tool.hatch.build.force-include]
+"../../bases/unittest/one" = "unittest/one"
+"../../components/unittest/two" = "unittest/two"
+
+[tool.hatch.build.hooks.targets.wheel.polylith.bricks]
+"something" = "else"
+"""
+
+expected = [
+    {"include": "unittest/one", "from": "../../bases"},
+    {"include": "unittest/two", "from": "../../components"},
+]
+
 
 def test_get_poetry_package_includes():
     data = tomlkit.loads(poetry_toml)
 
     res = project.get.get_project_package_includes(namespace, data)
 
-    assert res == [{"include": "unittest/one", "from": "../../components"}]
+    assert res == expected
 
 
-def test_get_pep_621_includes():
+def test_get_hatch_package_includes():
     data = tomlkit.loads(hatch_toml)
 
     res = project.get.get_project_package_includes(namespace, data)
 
-    assert res == [
-        {"include": "unittest/one", "from": "../../bases"},
-        {"include": "unittest/two", "from": "../../components"},
-    ]
+    assert res == expected
+
+
+def test_get_hatch_package_includes_in_build_hook():
+    data = tomlkit.loads(hatch_toml_alternative)
+
+    res = project.get.get_project_package_includes(namespace, data)
+
+    assert res == expected
+
+
+def test_get_hatch_package_includes_from_default_when_in_both():
+    data = tomlkit.loads(hatch_toml_combined)
+
+    res = project.get.get_project_package_includes(namespace, data)
+
+    assert res == expected

--- a/test/components/polylith/project/test_project_get.py
+++ b/test/components/polylith/project/test_project_get.py
@@ -1,5 +1,5 @@
-from polylith import project
 import tomlkit
+from polylith import project
 
 namespace = "unittest"
 
@@ -68,3 +68,15 @@ def test_get_hatch_package_includes_from_default_when_in_both():
     res = project.get.get_project_package_includes(namespace, data)
 
     assert res == expected
+
+
+def test_get_hatch_package_includes_lookup_with_unexpected_format():
+    unexpected = """\
+[tool.hatch.build.hooks.targets.wheel]
+"polylith" = "this-is-unexpected"
+"""
+    data = tomlkit.loads(unexpected)
+
+    res = project.get.get_project_package_includes(namespace, data)
+
+    assert res == []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Look for Polylith bricks in another TOML section, in addition to the Hatch build `force-include` section:
recursive lookup in the `tool.hatch.build` section and looking for `polylith.bricks`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Preparing for building libraries in a Hatch context, to be used by a build hook.

This will also simplify the development of the Hatch build hook.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Additional unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
