### PR TITLE
feat(cli): add Hatch library support

### DIFF
--- a/components/polylith/project/get.py
+++ b/components/polylith/project/get.py
@@ -24,6 +24,12 @@ def find_by_key(data: dict, key: str) -> Any:
     return next((r for r in res if r), None)
 
 
+def get_project_packages_from_polylith_section(data) -> dict:
+    bricks = data["tool"].get("polylith", {}).get("bricks")
+
+    return bricks if isinstance(bricks, dict) else {}
+
+
 def get_hatch_project_packages(data) -> dict:
     hatch_data = data["tool"]["hatch"]
     build_data = hatch_data.get("build", {}) if isinstance(hatch_data, dict) else {}
@@ -33,10 +39,7 @@ def get_hatch_project_packages(data) -> dict:
     if force_included:
         return force_included
 
-    found = find_by_key(build_data, "polylith")
-    bricks = found.get("bricks", {}) if isinstance(found, dict) else {}
-
-    return bricks if isinstance(bricks, dict) else {}
+    return get_project_packages_from_polylith_section(data)
 
 
 def get_project_package_includes(namespace: str, data) -> List[dict]:

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.14.2"
+version = "1.14.3"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith-cli/pyproject.toml
+++ b/projects/polylith-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/project/test_project_get.py
+++ b/test/components/polylith/project/test_project_get.py
@@ -18,7 +18,10 @@ hatch_toml = """\
 """
 
 hatch_toml_alternative = """\
-[tool.hatch.build.hooks.targets.wheel.polylith.bricks]
+[tool.hatch.build]
+something = "something"
+
+[tool.polylith.bricks]
 "../../bases/unittest/one" = "unittest/one"
 "../../components/unittest/two" = "unittest/two"
 """
@@ -28,7 +31,7 @@ hatch_toml_combined = """\
 "../../bases/unittest/one" = "unittest/one"
 "../../components/unittest/two" = "unittest/two"
 
-[tool.hatch.build.hooks.targets.wheel.polylith.bricks]
+[tool.polylith.bricks]
 "something" = "else"
 """
 
@@ -68,15 +71,3 @@ def test_get_hatch_package_includes_from_default_when_in_both():
     res = project.get.get_project_package_includes(namespace, data)
 
     assert res == expected
-
-
-def test_get_hatch_package_includes_lookup_with_unexpected_format():
-    unexpected = """\
-[tool.hatch.build.hooks.targets.wheel]
-"polylith" = "this-is-unexpected"
-"""
-    data = tomlkit.loads(unexpected)
-
-    res = project.get.get_project_package_includes(namespace, data)
-
-    assert res == []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for defining bricks in a separated TOML section, meant for a Build Hook to find and modify the Hatch build data.

`[tool.polylith.bricks]`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A step forward to support building libraries with a custom top-namepace when using Hatch.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ new/modified unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
