### PR TITLE
fix(poly check): f-string causing issues for Pythons less than 3.12

### DIFF
--- a/components/polylith/check/report.py
+++ b/components/polylith/check/report.py
@@ -18,10 +18,12 @@ def print_brick_imports(brick_imports: dict) -> None:
     for key, values in bricks.items():
         imports_in_brick = values.difference({key})
 
-        if imports_in_brick:
-            console.print(
-                f":information: [data]{key}[/] is importing [data]{', '.join(imports_in_brick)}[/]"
-            )
+        if not imports_in_brick:
+            continue
+
+        joined = ", ".join(imports_in_brick)
+        message = f":information: [data]{key}[/] is importing [data]{joined}[/]"
+        console.print(message)
 
 
 def print_missing_deps(diff: Set[str], project_name: str) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fix: the `poly check` command (using the `--verbose` option) crashing for Python versions lower han 3.12, because evaluating functions inline.

Solution: extract the string parsing and simplify the f-string usage.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #193 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Local testing with Python 3.8

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
