### PR TITLE
fix(cli): redundant Typer extras

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -807,6 +807,7 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
+    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 
@@ -1488,4 +1489,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "8489ce77364c49dbd6d9e5aef93133504cb38072b9beec52ab7f7be950de23f4"
+content-hash = "490290fb0e4cc473cd208646e9908947558e418430b04ba7d5006df78e075355"

--- a/projects/polylith_cli/poetry.lock
+++ b/projects/polylith_cli/poetry.lock
@@ -147,4 +147,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "451a5c93749813907c0504c8f2e975297992f72ba2a1741fc5e98b8993585a58"
+content-hash = "ef2b1941a2d4a4b206a71054002fae225dfd8a4c8f9a9a6130af802e0a41b842"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -39,7 +39,7 @@ packages = [
 python = "^3.8"
 tomlkit = "^0.11.5"
 rich = "^13.6.0"
-typer = {extras = ["all"], version = "0.*"}
+typer = "0.*"
 
 [tool.poetry.scripts]
 poly = "polylith_cli.polylith.cli.core:app"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.5.1"
+version = "1.5.2"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,9 @@ python = "^3.8.1"
 poetry = "^1.2"
 tomlkit = "^0.11.5"
 rich = "^13.6.0"
-typer = {extras = ["all"], version = "0.*"}
 cleo = "^2.1.0"
 hatchling = "^1.21.0"
+typer = "0.*"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.3.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove the `all` extras from Typer, no longer neeed according to the [release notes](https://typer.tiangolo.com/release-notes/#0121).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Installing the CLI raises a warning in the terminal after installation/env creation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
