### PR TITLE
Make `poly deps` work even though a component is not imported by anything.

### DIFF
--- a/components/polylith/deps/report.py
+++ b/components/polylith/deps/report.py
@@ -21,7 +21,7 @@ def brick_status(bricks: List[str], brick_name: str, imported: str) -> str:
 
 
 def to_row(name: str, tag: str, brick_imports: dict, imported: List[str]) -> List[str]:
-    bricks = brick_imports[name]
+    bricks = brick_imports.get(name) or set() 
     statuses = [brick_status(bricks, name, i) for i in imported]
 
     return [f"[{tag}]{name}[/]"] + statuses


### PR DESCRIPTION

## Description

I discovered a relatively harmless bug where `poly deps` will fail if a component imports another component, but is not itself imported anywhere. This leads to a KeyError in the visualisation code, which is probably not good. My fix is just to make the lookup return an empty set instead of raising an error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [ x ] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ x ] I have updated the documentation accordingly (if applicable).
