### PR TITLE
fix(hatch, rye and pdm hooks): building proper sdists

### DIFF
--- a/bases/polylith/pdm_project_hooks/core.py
+++ b/bases/polylith/pdm_project_hooks/core.py
@@ -8,4 +8,4 @@ def pdm_build_initialize(context):
 
     build_dir = Path(context.build_dir)
 
-    build_initialize(context.config.data, build_dir)
+    build_initialize(context.config.root, context.config.data, build_dir)

--- a/components/polylith/hatch/hooks/bricks.py
+++ b/components/polylith/hatch/hooks/bricks.py
@@ -11,19 +11,18 @@ class PolylithBricksHook(BuildHookInterface):
     PLUGIN_NAME = "polylith-bricks"
 
     def initialize(self, _version: str, build_data: Dict[str, Any]) -> None:
-        pyproject = Path(f"{self.root}/{repo.default_toml}")
-
-        print(f"Using {pyproject.as_posix()}.")
+        root = self.root
+        pyproject = Path(f"{root}/{repo.default_toml}")
 
         data = toml.read_toml_document(pyproject)
         bricks = toml.get_project_packages_from_polylith_section(data)
+        found_bricks = {k: v for k, v in bricks.items() if Path(f"{root}/{k}").exists()}
+
+        if not bricks or not found_bricks:
+            return
 
         top_ns = core.get_top_namespace(data, self.config)
         work_dir = core.get_work_dir(self.config)
-
-        if not bricks:
-            print("No bricks found.")
-            return
 
         if not top_ns:
             build_data["force_include"] = bricks

--- a/components/polylith/pdm/hooks/bricks.py
+++ b/components/polylith/pdm/hooks/bricks.py
@@ -4,14 +4,15 @@ from polylith import toml
 from polylith.pdm import core
 
 
-def build_initialize(config_data: dict, build_dir: Path) -> None:
+def build_initialize(root: Path, config_data: dict, build_dir: Path) -> None:
     bricks = toml.get_project_packages_from_polylith_section(config_data)
+    found_bricks = {k: v for k, v in bricks.items() if Path(root / k).exists()}
+
+    if not bricks or not found_bricks:
+        return
+
     top_ns = toml.get_custom_top_namespace_from_polylith_section(config_data)
     work_dir = core.get_work_dir(config_data)
-
-    if not bricks:
-        print("No bricks found.")
-        return
 
     if not top_ns:
         core.copy_bricks_as_is(bricks, build_dir)

--- a/projects/hatch_polylith_bricks/pyproject.toml
+++ b/projects/hatch_polylith_bricks/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatch-polylith-bricks"
-version = "1.2.2"
+version = "1.2.3"
 description = "Hatch build hook plugin for Polylith"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/pdm_polylith_bricks/pyproject.toml
+++ b/projects/pdm_polylith_bricks/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdm-polylith-bricks"
-version = "1.0.2"
+version = "1.0.3"
 description = "a PDM build hook for Polylith"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/pdm_polylith_workspace/pyproject.toml
+++ b/projects/pdm_polylith_workspace/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdm-polylith-workspace"
-version = "1.0.2"
+version = "1.0.3"
 description = "a PDM build hook for a Polylith workspace"
 homepage = "https://davidvujic.github.io/python-polylith-docs/"
 repository = "https://github.com/davidvujic/python-polylith"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixing an issue with the built `sdist` for hatch and pdm, indirectly also rye (using hatch).

Building wheels is not affected by this bug.

The issue is causing failed installs from an sdist, because the build hooks were triggered and trying to copy the relative bricks. 

This fix will exit the hook if there is no valid bricks to copy, i.e. from an sdist where all code is already put in place.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Making it possible to install a built library from an sdist.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Locally running code in a REPL

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [ ] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
