### PR TITLE
Allow setting sorting options for git tags in diff command

### DIFF
--- a/components/polylith/configuration/__init__.py
+++ b/components/polylith/configuration/__init__.py
@@ -3,6 +3,7 @@ from polylith.configuration.core import (
     get_namespace_from_config,
     get_resources_structure_from_config,
     get_tag_pattern_from_config,
+    get_tag_sort_options_from_config,
     get_tests_structure_from_config,
     get_theme_from_config,
     is_readme_generation_enabled,

--- a/components/polylith/configuration/core.py
+++ b/components/polylith/configuration/core.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 import tomlkit
 from polylith import repo
@@ -35,6 +35,16 @@ def get_tag_pattern_from_config(path: Path, key: Union[str, None]) -> str:
     patterns = toml["tool"]["polylith"].get("tag", {}).get("patterns")
 
     return patterns[key or "stable"] if patterns else get_git_tag_pattern(toml)
+
+
+def get_tag_sort_options_from_config(path: Path) -> List[str]:
+    toml: dict = _load_workspace_config(path)
+
+    options = toml["tool"]["polylith"].get("tag", {}).get("sorting")
+    # Default sorting option
+    if options is None:
+        return ["-committerdate"]
+    return options
 
 
 def is_test_generation_enabled(path: Path) -> bool:

--- a/components/polylith/diff/collect.py
+++ b/components/polylith/diff/collect.py
@@ -43,9 +43,13 @@ def get_changed_projects(changed_files: List[Path]) -> list:
 
 def get_latest_tag(root: Path, key: Union[str, None]) -> Union[str, None]:
     tag_pattern = configuration.get_tag_pattern_from_config(root, key)
+    sorting_options = [
+        f"--sort={option}"
+        for option in configuration.get_tag_sort_options_from_config(root)
+    ]
 
     res = subprocess.run(
-        ["git", "tag", "-l", "--sort=-committerdate", f"{tag_pattern}"],
+        ["git", "tag", "-l"] + sorting_options + [f"{tag_pattern}"],
         capture_output=True,
     )
 


### PR DESCRIPTION
## Description
This change adds a new option to the `workspace.toml` configuration that allows you to change the behavior of the diff command when ordering tags.

The original behavior doesn't change, but this will allow you to use different sorting based on the `tool.polylith.tag.sorting` configuration, that is an array of options that are passed to the git command.

I wasn't able to find the right place to document this behavior, so any pointers to that would be great.

## Motivation and Context
While integrating the polylith in a project, I noticed that there's a difference of behavior when using annotated tags, vs non annotated tags with the diff command.

When using annotated tags the `-committerdate` sorting option doesn't take into account the annotated tags, making the tags come back in an order that is not expected.
In the following example I tagged two commits, the first one using light-weight tags and the other one using an annotated tag. After executing the git command we can see that they came back out of order, but if we use the `-creatordate` sorting option it comes back in the right order.
![Screenshot 2024-06-05 at 12 41 13 PM](https://github.com/DavidVujic/python-polylith/assets/92755157/defde0fd-a7ef-4bf3-9a70-3e415dbbd1c0)

## How Has This Been Tested?
I added unit tests for the configuration change, and tested the command locally to make sure that it continued to work as expected.
With default configuration:
![Screenshot 2024-06-05 at 12 56 22 PM](https://github.com/DavidVujic/python-polylith/assets/92755157/c6453f7d-00ea-4760-a5db-0d1bcffe3a8b)

With the `-creatordate` configuration:
```toml
[tool.polylith.tag]
sorting = ["-creatordate"]
```
![Screenshot 2024-06-05 at 12 57 43 PM](https://github.com/DavidVujic/python-polylith/assets/92755157/11f068d1-e5a3-42cb-9e14-eaad434235ed)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
