### PR TITLE
Fix error handling when missing project name

### DIFF
--- a/components/polylith/project/get.py
+++ b/components/polylith/project/get.py
@@ -6,11 +6,20 @@ import tomlkit
 from polylith import configuration, repo, toml
 
 
-def get_project_name(data) -> str:
-    if repo.is_pep_621_ready(data):
-        return data["project"]["name"]
+def get_project_name(toml_data) -> str:
+    if repo.is_pep_621_ready(toml_data):
+        return toml_data["project"]["name"]
 
-    return data["tool"]["poetry"]["name"]
+    return toml_data["tool"]["poetry"]["name"]
+
+
+def get_project_name_from_toml(data: dict) -> str:
+    try:
+        return get_project_name(data["toml"])
+    except KeyError as e:
+        path = data["path"]
+
+        raise KeyError(f"Error in {path}") from e
 
 
 @lru_cache
@@ -47,7 +56,7 @@ def get_packages_for_projects(root: Path) -> List[dict]:
 
     return [
         {
-            "name": get_project_name(d["toml"]),
+            "name": get_project_name_from_toml(d),
             "packages": toml.get_project_package_includes(namespace, d["toml"]),
             "path": d["path"],
             "type": d["type"],

--- a/components/polylith/toml/core.py
+++ b/components/polylith/toml/core.py
@@ -56,13 +56,6 @@ def get_project_package_includes(namespace: str, data) -> List[dict]:
     return [transform_to_package(namespace, key) for key in includes.keys()]
 
 
-def get_project_name(data) -> str:
-    if repo.is_pep_621_ready(data):
-        return data["project"]["name"]
-
-    return data["tool"]["poetry"]["name"]
-
-
 def parse_pep_621_dependency(dep: str) -> dict:
     parts = re.split(r"[\^~=!<>]", dep)
 

--- a/projects/hatch_polylith_bricks/pyproject.toml
+++ b/projects/hatch_polylith_bricks/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatch-polylith-bricks"
-version = "1.2.3"
+version = "1.2.4"
 description = "Hatch build hook plugin for Polylith"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/pdm_polylith_bricks/pyproject.toml
+++ b/projects/pdm_polylith_bricks/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdm-polylith-bricks"
-version = "1.0.4"
+version = "1.0.5"
 description = "a PDM build hook for Polylith"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/pdm_polylith_workspace/pyproject.toml
+++ b/projects/pdm_polylith_workspace/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdm-polylith-workspace"
-version = "1.0.4"
+version = "1.0.5"
 description = "a PDM build hook for a Polylith workspace"
 homepage = "https://davidvujic.github.io/python-polylith-docs/"
 repository = "https://github.com/davidvujic/python-polylith"

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.20.0"
+version = "1.20.1"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.7.0"
+version = "1.7.1"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/project/test_project_get.py
+++ b/test/components/polylith/project/test_project_get.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import tomlkit
+from polylith.project import get
+import pytest
+
+
+poetry_toml = """\
+[tool.poetry]
+name = "unit-test"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+"""
+
+pep_621_toml = """\
+[project]
+name = "unit-test"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+"""
+
+
+def test_get_project_name_from_poetry_project():
+    data = {"toml": tomlkit.loads(poetry_toml), "path": Path.cwd()}
+
+    assert get.get_project_name_from_toml(data) == "unit-test"
+
+
+def test_get_project_name_from_pep_621_project():
+    data = {"toml": tomlkit.loads(pep_621_toml), "path": Path.cwd()}
+
+    assert get.get_project_name_from_toml(data) == "unit-test"
+
+
+def test_fetching_project_name_from_empty_project_raises_error():
+    path = Path.cwd()
+
+    data = {"toml": tomlkit.loads(""), "path": path}
+
+    with pytest.raises(KeyError) as e:
+        get.get_project_name_from_toml(data)
+
+    assert str(path) in str(e.value)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Handle `KeyError` from tomlkit when fetching the project name, by adding extra information about the path to the project file with missing key.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To make it clearer where the problem happens.

Solves #215 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ added unitt tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
