### PR TITLE
fix(projects): find project files at the sub directory of the "projects" folder

### DIFF
--- a/components/polylith/project/get.py
+++ b/components/polylith/project/get.py
@@ -28,7 +28,7 @@ def get_toml(path: Path) -> tomlkit.TOMLDocument:
 
 
 def get_project_files(root: Path) -> dict:
-    projects = sorted(root.glob(f"projects/**/{repo.default_toml}"))
+    projects = sorted(root.glob(f"projects/*/{repo.default_toml}"))
     development = Path(root / repo.default_toml)
 
     proj = {"projects": projects}

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.22.1"
+version = "1.23.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.9.1"
+version = "1.10.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Look for the project-specific `pyproject.toml` files at one sub-directory of the `projects` folder only.

Not traversing all sub-directories of each projects folder.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To avoid fetching any project files in a project-local `.venv` (even if that is not recommended to have there).

fixes #215 

This is a bug fix, and also a behaviour change and that is the reason for the minor version bumps in the Poetry plugin and in the CLI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Locally testing commands

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
