### PR TITLE
fix(poly check, poly libs): proper parse of third party lib names that contains extras

### DIFF
--- a/components/polylith/distributions/core.py
+++ b/components/polylith/distributions/core.py
@@ -25,10 +25,16 @@ def map_sub_packages(acc, dist) -> dict:
     return {**acc, **dist_subpackages(dist)}
 
 
+def parsed_top_level_namespace(namespaces: List[str]) -> List[str]:
+    return [str.replace(ns, "/", ".") for ns in namespaces]
+
+
 def top_level_packages(dist) -> List[str]:
     top_level = dist.read_text("top_level.txt")
 
-    return str.split(top_level or "")
+    namespaces = str.split(top_level or "")
+
+    return parsed_top_level_namespace(namespaces)
 
 
 def mapped_packages(dist) -> dict:

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.23.0"
+version = "1.23.1"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.10.0"
+version = "1.10.1"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/distributions/test_collect.py
+++ b/test/components/polylith/distributions/test_collect.py
@@ -1,0 +1,30 @@
+from polylith.distributions import collect
+
+
+def test_parse_third_party_library_name():
+    fake_project_deps = {
+        "items": {
+            "python": "^3.10",
+            "fastapi": "^0.110.0",
+            "uvicorn[standard]": "^0.27.1",
+            "python-jose[cryptography]": "^3.3.0",
+            "hello[world, something]": "^3.3.0"
+        },
+        "source": "pyproject.toml",
+    }
+
+    expected = {
+        "python",
+        "fastapi",
+        "uvicorn",
+        "standard",
+        "python-jose",
+        "cryptography",
+        "hello",
+        "world",
+        "something",
+    }
+
+    res = collect.extract_library_names(fake_project_deps)
+
+    assert res == expected

--- a/test/components/polylith/distributions/test_core.py
+++ b/test/components/polylith/distributions/test_core.py
@@ -5,6 +5,15 @@ import pytest
 from polylith import distributions
 
 
+class FakeDist:
+    def __init__(self, name: str, data: str):
+        self.data = data
+        self.metadata = {"name": name}
+
+    def read_text(self, *args):
+        return self.data
+
+
 def test_distribution_packages():
     dists = list(importlib.metadata.distributions())
 
@@ -15,6 +24,18 @@ def test_distribution_packages():
 
     assert res.get(expected_dist) is not None
     assert res[expected_dist] == [expected_package]
+
+
+def test_distribution_packages_parse_contents_of_top_level_txt():
+    dists = [FakeDist("python-jose", "jose\njose/backends\n")]
+
+    res = distributions.distributions_packages(dists)
+
+    expected_dist = "python-jose"
+    expected_packages = ["jose", "jose.backends"]
+
+    assert res.get(expected_dist) is not None
+    assert res[expected_dist] == expected_packages
 
 
 def test_parse_package_name_from_dist_requires():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Parse the third-party library names that contains "extras", such as `uvicorn[standard]` and `python-jose[cryptography]`. The changes in this pull request will split the library name and extras into separate items in the result set, such as `uvicorn, standard, python-jose, cryptography`.

Also: properly parse distribution top-level namespaces where defined with `/`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #229
that was reported in https://github.com/DavidVujic/python-polylith/discussions/209#discussioncomment-10016618

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ added unit tests
✅ local run of libs and check commands

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
