### PR TITLE
feat(poly check): parse any included top-level namespaces from the files list of a distribution

### DIFF
--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.25.1"
+version = "1.26.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.12.1"
+version = "1.13.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/distributions/test_core.py
+++ b/test/components/polylith/distributions/test_core.py
@@ -1,20 +1,30 @@
 import importlib.metadata
 import sys
+from typing import Union
 
 import pytest
 from polylith import distributions
 
 
+@pytest.fixture
+def reset():
+    distributions.core.parsed_namespaces_from_files.cache_clear()
+
+
 class FakeDist:
-    def __init__(self, name: str, data: str):
-        self.data = data
+    def __init__(
+        self,
+        name: str,
+        read_text_data: Union[str, None] = None,
+    ):
+        self.read_text_data = read_text_data
         self.metadata = {"name": name}
 
     def read_text(self, *args):
-        return self.data
+        return self.read_text_data
 
 
-def test_distribution_packages():
+def test_distribution_packages(reset):
     dists = list(importlib.metadata.distributions())
 
     res = distributions.distributions_packages(dists)
@@ -26,7 +36,7 @@ def test_distribution_packages():
     assert res[expected_dist] == [expected_package]
 
 
-def test_distribution_packages_parse_contents_of_top_level_txt():
+def test_distribution_packages_parse_contents_of_top_level_txt(reset):
     dists = [FakeDist("python-jose", "jose\njose/backends\n")]
 
     res = distributions.distributions_packages(dists)
@@ -38,7 +48,40 @@ def test_distribution_packages_parse_contents_of_top_level_txt():
     assert res[expected_dist] == expected_packages
 
 
-def test_parse_package_name_from_dist_requires():
+def test_distribution_packages_with_no_top_level_ns_information(reset, monkeypatch):
+    monkeypatch.setattr(
+        distributions.core.importlib.metadata, "files", lambda name: None
+    )
+
+    dists = [FakeDist("some_package")]
+
+    res = distributions.distributions_packages(dists)
+
+    assert res == {}
+
+
+def test_distribution_packages_with_top_level_ns_information_in_files(
+    reset, monkeypatch
+):
+    files = [
+        importlib.metadata.PackagePath("some_module.py"),
+        importlib.metadata.PackagePath("hello/world.py"),
+        importlib.metadata.PackagePath("some_package/some_module.py"),
+        importlib.metadata.PackagePath("something/else.sh"),
+    ]
+
+    monkeypatch.setattr(
+        distributions.core.importlib.metadata, "files", lambda name: files
+    )
+
+    dists = [FakeDist("some_package")]
+
+    res = distributions.distributions_packages(dists)
+
+    assert res == {"some_package": ["hello"]}
+
+
+def test_parse_package_name_from_dist_requires(reset):
     expected = {
         "greenlet": "greenlet !=0.4.17",
         "mysqlclient": "mysqlclient >=1.4.0 ; extra == 'mysql'",
@@ -53,7 +96,7 @@ def test_parse_package_name_from_dist_requires():
         assert k == distributions.core.parse_sub_package_name(v)
 
 
-def test_distribution_sub_packages():
+def test_distribution_sub_packages(reset):
     dists = list(importlib.metadata.distributions())
 
     res = distributions.distributions_sub_packages(dists)
@@ -66,7 +109,7 @@ def test_distribution_sub_packages():
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
-def test_package_distributions_returning_top_namespace(monkeypatch):
+def test_package_distributions_returning_top_namespace(reset, monkeypatch):
     fake_dists = {
         "something": ["something-subnamespace"],
         "opentelemetry": ["opentelemetry-instrumentation-fastapi"],
@@ -93,7 +136,7 @@ def test_package_distributions_returning_top_namespace(monkeypatch):
 
 
 @pytest.mark.skipif(sys.version_info > (3, 9), reason="asserting python3.9 and lower")
-def test_package_distributions_returning_empty_set():
+def test_package_distributions_returning_empty_set(reset):
     fake_project_deps = {"something-subnamespace"}
 
     res = distributions.core.get_packages_distributions(fake_project_deps)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Find top-level namespaces - the top folder name - by looking into the file paths list of a distribution.

This will add additional top namespaces to the list that is used when comparing imports in the modules with the installed libraries.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some third-party libraries include sub-packages not as dependencies, but as adjacent packages.

One example is `pymongo` that includes the `bson` package.

See discussion covering this topic: https://github.com/DavidVujic/python-polylith/discussions/209#discussioncomment-10078102

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ added unit test
✅ local run of the `poly check` and `poly libs` commands

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
