### PR TITLE
fix(poly check, poly libs): handle missing metadata errors

### DIFF
--- a/components/polylith/distributions/core.py
+++ b/components/polylith/distributions/core.py
@@ -29,9 +29,16 @@ def parsed_top_level_namespace(namespaces: List[str]) -> List[str]:
     return [str.replace(ns, "/", ".") for ns in namespaces]
 
 
+def get_files_from_metadata(name: str) -> list:
+    try:
+        return importlib.metadata.files(name) or []
+    except importlib.metadata.PackageNotFoundError:
+        return []
+
+
 @lru_cache
 def parsed_namespaces_from_files(name: str) -> List[str]:
-    files = importlib.metadata.files(name) or []
+    files = get_files_from_metadata(name)
 
     normalized_name = str.replace(name, "-", "_")
     to_ignore = {

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.26.0"
+version = "1.26.1"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.13.0"
+version = "1.13.1"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/distributions/test_core.py
+++ b/test/components/polylith/distributions/test_core.py
@@ -60,6 +60,14 @@ def test_distribution_packages_with_no_top_level_ns_information(reset, monkeypat
     assert res == {}
 
 
+def test_distribution_packages_for_missing_metadata_is_handled(reset):
+    dists = [FakeDist("some_package")]
+
+    res = distributions.distributions_packages(dists)
+
+    assert res == {}
+
+
 def test_distribution_packages_with_top_level_ns_information_in_files(
     reset, monkeypatch
 ):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Handle missing distribution metadata errors, when doing distribution files list lookup.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To prevent errors for the `poly check` and `poly libs` commands for identified top-ns packages without metadata.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ added unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
