### PR TITLE
fix(poly check, poly libs): distribution files from package distribution object

### DIFF
--- a/components/polylith/distributions/core.py
+++ b/components/polylith/distributions/core.py
@@ -25,20 +25,9 @@ def map_sub_packages(acc, dist) -> dict:
     return {**acc, **dist_subpackages(dist)}
 
 
-def parsed_top_level_namespace(namespaces: List[str]) -> List[str]:
-    return [str.replace(ns, "/", ".") for ns in namespaces]
-
-
-def get_files_from_metadata(name: str) -> list:
-    try:
-        return importlib.metadata.files(name) or []
-    except importlib.metadata.PackageNotFoundError:
-        return []
-
-
-@lru_cache
-def parsed_namespaces_from_files(name: str) -> List[str]:
-    files = get_files_from_metadata(name)
+def parsed_namespaces_from_files(dist) -> List[str]:
+    name = dist.metadata["name"]
+    files = dist.files or []
 
     normalized_name = str.replace(name, "-", "_")
     to_ignore = {
@@ -56,13 +45,16 @@ def parsed_namespaces_from_files(name: str) -> List[str]:
     return list(namespaces)
 
 
+def parsed_top_level_namespace(namespaces: List[str]) -> List[str]:
+    return [str.replace(ns, "/", ".") for ns in namespaces]
+
+
 def top_level_packages(dist) -> List[str]:
-    name = dist.metadata["name"]
     top_level = dist.read_text("top_level.txt")
 
     namespaces = str.split(top_level or "")
 
-    return parsed_top_level_namespace(namespaces) or parsed_namespaces_from_files(name)
+    return parsed_top_level_namespace(namespaces) or parsed_namespaces_from_files(dist)
 
 
 def mapped_packages(dist) -> dict:

--- a/components/polylith/poetry/internals.py
+++ b/components/polylith/poetry/internals.py
@@ -14,6 +14,16 @@ def get_project_poetry(poetry: Poetry, path: Union[Path, None]) -> Poetry:
 
 @lru_cache
 def distributions(poetry: Poetry, path: Union[Path, None]) -> list:
+    """Get distributions from the current Poetry context.
+
+    When running code within Poetry, the current environment is the one Poetry uses and
+    not the environment in the current project or workspace.
+
+    Querying importlib.metadata will fail to find the libraries added to the workspace.
+
+    This function uses the Poetry internals to fetch the distributions,
+    that internally queries the metadata based on the current path.
+    """
     project_poetry = get_project_poetry(poetry, path)
 
     env = EnvManager(project_poetry).get()

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.26.1"
+version = "1.26.2"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.13.1"
+version = "1.13.2"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes an issue with querying the distribution metadata when using the `Poetry` plugin.

When running the poly commands within the Poetry plugin, the current environment is the one used by Poetry itself. This makes querying distributions using the `importlib.metadata` incorrect.

This Pull Request contains code that uses Poetry internals to fetch the distributions. The Poetry internals does a distribution discovery based on the current file path. This will produce a list of distributions that is located in the current path.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To be able to find adjacent packages like `bson`, added by libraries like `pymongo`.

Details in discussion: https://github.com/DavidVujic/python-polylith/discussions/209#discussioncomment-10078102

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ unit tests
✅ Local install of the Poetry plugin, running the `poly check` and `poly libs`commands

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
