### PR TITLE
feat(poly diff): include data for bricks dependent on changed bricks

### DIFF
--- a/bases/polylith/cli/core.py
+++ b/bases/polylith/cli/core.py
@@ -86,9 +86,14 @@ def diff_command(
     since: Annotated[str, Option(help="Changed since a specific tag.")] = "",
     short: Annotated[bool, options.short] = False,
     bricks: Annotated[bool, Option(help="Print changed bricks.")] = False,
+    deps: Annotated[
+        bool, Option(help="Print bricks that depend on changes. Use with --bricks.")
+    ] = False,
 ):
     """Shows changed bricks compared to the latest git tag."""
-    commands.diff.run(since, short, bricks)
+    options = {"short": short, "bricks": bricks, "deps": deps}
+
+    commands.diff.run(since, options)
 
 
 @app.command("libs")

--- a/components/polylith/commands/diff.py
+++ b/components/polylith/commands/diff.py
@@ -1,12 +1,19 @@
 from pathlib import Path
 from typing import Union
 
-from polylith import configuration, diff, info, repo
+from polylith import configuration, deps, diff, info, repo
+
+
+def get_imports(root: Path, ns: str, bases: list, components: list) -> dict:
+    brick_imports = deps.get_brick_imports(root, ns, set(bases), set(components))
+
+    return {**brick_imports["bases"], **brick_imports["components"]}
 
 
 def print_views(root: Path, tag: str, options: dict) -> None:
     short = options.get("short", False)
     only_bricks = options.get("bricks", False)
+    with_deps = only_bricks and options.get("deps", False)
 
     ns = configuration.get_namespace_from_config(root)
     files = diff.collect.get_files(tag)
@@ -33,7 +40,9 @@ def print_views(root: Path, tag: str, options: dict) -> None:
 
         return
 
-    diff.report.print_detected_changes_in_bricks(bases, components, options)
+    imports = get_imports(root, ns, bases, components) if with_deps else {}
+
+    diff.report.print_detected_changes_in_bricks(bases, components, imports, options)
 
 
 def run(tag_name: Union[str, None], options: dict):

--- a/components/polylith/commands/diff.py
+++ b/components/polylith/commands/diff.py
@@ -49,8 +49,8 @@ def calculate_dependent_bricks(
         changed_bricks, bases, components, import_data
     )
 
-    dependent_bases = sorted({b for b in dependent_bricks if b in bases})
-    dependent_components = sorted({c for c in dependent_bricks if c in components})
+    dependent_bases = {b for b in dependent_bricks if b in bases}
+    dependent_components = {c for c in dependent_bricks if c in components}
 
     return {"bases": dependent_bases, "components": dependent_components}
 
@@ -58,7 +58,7 @@ def calculate_dependent_bricks(
 def print_views(root: Path, tag: str, options: dict) -> None:
     short = options.get("short", False)
     only_bricks = options.get("bricks", False)
-    with_deps = only_bricks and options.get("deps", False)
+    with_deps = options.get("deps", False)
 
     ns = configuration.get_namespace_from_config(root)
     files = diff.collect.get_files(tag)

--- a/components/polylith/commands/diff.py
+++ b/components/polylith/commands/diff.py
@@ -4,7 +4,10 @@ from typing import Union
 from polylith import configuration, diff, info, repo
 
 
-def print_views(root: Path, tag: str, short: bool, only_bricks: bool) -> None:
+def print_views(root: Path, tag: str, options: dict) -> None:
+    short = options.get("short", False)
+    only_bricks = options.get("bricks", False)
+
     ns = configuration.get_namespace_from_config(root)
     files = diff.collect.get_files(tag)
     bases = diff.collect.get_changed_bases(root, files, ns)
@@ -30,10 +33,10 @@ def print_views(root: Path, tag: str, short: bool, only_bricks: bool) -> None:
 
         return
 
-    diff.report.print_detected_changes_in_bricks(bases, components, short)
+    diff.report.print_detected_changes_in_bricks(bases, components, options)
 
 
-def run(tag_name: Union[str, None], short: bool, only_bricks: bool):
+def run(tag_name: Union[str, None], options: dict):
     root = repo.get_workspace_root(Path.cwd())
 
     tag = diff.collect.get_latest_tag(root, tag_name)
@@ -42,4 +45,4 @@ def run(tag_name: Union[str, None], short: bool, only_bricks: bool):
         print("No tags found in repository.")
         return
 
-    print_views(root, tag, short, only_bricks)
+    print_views(root, tag, options)

--- a/components/polylith/commands/diff.py
+++ b/components/polylith/commands/diff.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 from polylith import configuration, deps, diff, info, repo
 
@@ -10,6 +10,12 @@ def get_imports(root: Path, ns: str, bases: list, components: list) -> dict:
     return {**brick_imports["bases"], **brick_imports["components"]}
 
 
+def get_projects_data(root: Path, ns: str) -> List[dict]:
+    data = info.get_projects_data(root, ns)
+
+    return [p for p in data if info.is_project(p)]
+
+
 def print_views(root: Path, tag: str, options: dict) -> None:
     short = options.get("short", False)
     only_bricks = options.get("bricks", False)
@@ -17,32 +23,35 @@ def print_views(root: Path, tag: str, options: dict) -> None:
 
     ns = configuration.get_namespace_from_config(root)
     files = diff.collect.get_files(tag)
-    bases = diff.collect.get_changed_bases(root, files, ns)
-    components = diff.collect.get_changed_components(root, files, ns)
 
-    projects = diff.collect.get_changed_projects(files)
-    all_projects_data = info.get_bricks_in_projects(root, components, bases, ns)
-    projects_data = [p for p in all_projects_data if info.is_project(p)]
+    changed_bases = diff.collect.get_changed_bases(root, files, ns)
+    changed_components = diff.collect.get_changed_components(root, files, ns)
+    changed_projects = diff.collect.get_changed_projects(files)
 
-    affected_projects = diff.collect.get_projects_affected_by_changes(
-        projects_data, projects, bases, components
-    )
+    projects_data = get_projects_data(root, ns)
 
     if not short and not only_bricks:
-        diff.report.print_diff_summary(tag, bases, components)
-        diff.report.print_detected_changes_in_projects(projects, short)
-        diff.report.print_diff_details(projects_data, bases, components)
+        diff.report.print_diff_summary(tag, changed_bases, changed_components)
+        diff.report.print_detected_changes_in_projects(changed_projects, short)
+        diff.report.print_diff_details(projects_data, changed_bases, changed_components)
 
         return
 
     if short and not only_bricks:
+        affected_projects = diff.collect.get_projects_affected_by_changes(
+            projects_data, changed_projects, changed_bases, changed_components
+        )
         diff.report.print_projects_affected_by_changes(affected_projects, short)
 
         return
 
-    imports = get_imports(root, ns, bases, components) if with_deps else {}
+    imports = (
+        get_imports(root, ns, changed_bases, changed_components) if with_deps else {}
+    )
 
-    diff.report.print_detected_changes_in_bricks(bases, components, imports, options)
+    diff.report.print_detected_changes_in_bricks(
+        changed_bases, changed_components, imports, options
+    )
 
 
 def run(tag_name: Union[str, None], options: dict):

--- a/components/polylith/diff/report.py
+++ b/components/polylith/diff/report.py
@@ -37,11 +37,14 @@ def print_detected_changes(changes: List[str], markup: str, short: bool) -> None
 
 
 def print_detected_changes_in_bricks(
-    bases: List[str], components: List[str], imports: dict, options: dict,
+    changed_bases: List[str],
+    changed_components: List[str],
+    import_data: dict,
+    options: dict,
 ) -> None:
     short = options.get("short", False)
-    sorted_bases = sorted(bases)
-    sorted_components = sorted(components)
+    sorted_bases = sorted(changed_bases)
+    sorted_components = sorted(changed_components)
 
     if short:
         print_detected_changes(sorted_components + sorted_bases, "data", short)

--- a/components/polylith/diff/report.py
+++ b/components/polylith/diff/report.py
@@ -36,21 +36,49 @@ def print_detected_changes(changes: List[str], markup: str, short: bool) -> None
         console.print(f"[data]:gear: Changes found in [/][{markup}]{brick}[/]")
 
 
+def calculate_print_friendly_brick_type(bricks: List[str], markup: str) -> str:
+    plural = len(bricks) > 1
+
+    if markup == "base":
+        return "bases" if plural else "base"
+
+    return "components" if plural else "component"
+
+
+def print_detected_dependent(bricks: List[str], markup: str) -> None:
+    if not bricks:
+        return
+
+    console = Console(theme=theme.poly_theme)
+
+    brick_type = calculate_print_friendly_brick_type(bricks, markup)
+    printable_bricks = [f"[{markup}]{b}[/]" for b in bricks]
+    joined = ", ".join(printable_bricks)
+
+    console.print(f"[data]:gear: Dependent {brick_type}: [/]{joined}")
+
+
 def print_detected_changes_in_bricks(
     changed_bases: List[str],
     changed_components: List[str],
-    import_data: dict,
+    dependent_bricks: dict,
     options: dict,
 ) -> None:
     short = options.get("short", False)
-    sorted_bases = sorted(changed_bases)
-    sorted_components = sorted(changed_components)
+    bases = sorted(changed_bases)
+    components = sorted(changed_components)
+
+    dependent_bases = sorted(dependent_bricks.get("bases", []))
+    dependent_components = sorted(dependent_bricks.get("components", []))
 
     if short:
-        print_detected_changes(sorted_components + sorted_bases, "data", short)
+        bricks = components + bases + dependent_components + dependent_bases
+        print_detected_changes(bricks, "data", short)
     else:
-        print_detected_changes(sorted_components, "comp", short)
-        print_detected_changes(sorted_bases, "base", short)
+        print_detected_changes(components, "comp", short)
+        print_detected_changes(bases, "base", short)
+        print_detected_dependent(dependent_components, "comp")
+        print_detected_dependent(dependent_bases, "base")
 
 
 def print_detected_changes_in_projects(projects: List[str], short: bool) -> None:

--- a/components/polylith/diff/report.py
+++ b/components/polylith/diff/report.py
@@ -37,7 +37,7 @@ def print_detected_changes(changes: List[str], markup: str, short: bool) -> None
 
 
 def print_detected_changes_in_bricks(
-    bases: List[str], components: List[str], options: dict,
+    bases: List[str], components: List[str], imports: dict, options: dict,
 ) -> None:
     short = options.get("short", False)
     sorted_bases = sorted(bases)

--- a/components/polylith/diff/report.py
+++ b/components/polylith/diff/report.py
@@ -37,8 +37,9 @@ def print_detected_changes(changes: List[str], markup: str, short: bool) -> None
 
 
 def print_detected_changes_in_bricks(
-    bases: List[str], components: List[str], short: bool
+    bases: List[str], components: List[str], options: dict,
 ) -> None:
+    short = options.get("short", False)
     sorted_bases = sorted(bases)
     sorted_components = sorted(components)
 

--- a/components/polylith/diff/report.py
+++ b/components/polylith/diff/report.py
@@ -36,26 +36,16 @@ def print_detected_changes(changes: List[str], markup: str, short: bool) -> None
         console.print(f"[data]:gear: Changes found in [/][{markup}]{brick}[/]")
 
 
-def calculate_print_friendly_brick_type(bricks: List[str], markup: str) -> str:
-    plural = len(bricks) > 1
-
-    if markup == "base":
-        return "bases" if plural else "base"
-
-    return "components" if plural else "component"
-
-
-def print_detected_dependent(bricks: List[str], markup: str) -> None:
-    if not bricks:
-        return
-
+def print_detected_dependent(bases: List[str], components: List[str]) -> None:
     console = Console(theme=theme.poly_theme)
 
-    brick_type = calculate_print_friendly_brick_type(bricks, markup)
-    printable_bricks = [f"[{markup}]{b}[/]" for b in bricks]
-    joined = ", ".join(printable_bricks)
+    printable_bases = [f"[base]{b}[/]" for b in bases]
+    printable_components = [f"[comp]{c}[/]" for c in components]
 
-    console.print(f"[data]:gear: Dependent {brick_type}: [/]{joined}")
+    printable_bricks = printable_components + printable_bases
+    joined = ", ".join(printable_bricks) or "-"
+
+    console.print(f"[data]:gear: Used by: [/]{joined}")
 
 
 def print_detected_changes_in_bricks(
@@ -65,6 +55,8 @@ def print_detected_changes_in_bricks(
     options: dict,
 ) -> None:
     short = options.get("short", False)
+    with_deps = options.get("deps", False)
+
     bases = sorted(changed_bases)
     components = sorted(changed_components)
 
@@ -74,11 +66,14 @@ def print_detected_changes_in_bricks(
     if short:
         bricks = components + bases + dependent_components + dependent_bases
         print_detected_changes(bricks, "data", short)
-    else:
-        print_detected_changes(components, "comp", short)
-        print_detected_changes(bases, "base", short)
-        print_detected_dependent(dependent_components, "comp")
-        print_detected_dependent(dependent_bases, "base")
+
+        return
+
+    print_detected_changes(components, "comp", short)
+    print_detected_changes(bases, "base", short)
+
+    if with_deps:
+        print_detected_dependent(dependent_bases, dependent_components)
 
 
 def print_detected_changes_in_projects(projects: List[str], short: bool) -> None:

--- a/components/polylith/diff/report.py
+++ b/components/polylith/diff/report.py
@@ -57,20 +57,17 @@ def print_detected_changes_in_bricks(
     short = options.get("short", False)
     with_deps = options.get("deps", False)
 
-    bases = sorted(changed_bases)
-    components = sorted(changed_components)
+    dependent_bases = sorted(dependent_bricks.get("bases", set()))
+    dependent_components = sorted(dependent_bricks.get("components", set()))
 
-    dependent_bases = sorted(dependent_bricks.get("bases", []))
-    dependent_components = sorted(dependent_bricks.get("components", []))
+    bricks = changed_components + changed_bases + dependent_components + dependent_bases
 
     if short:
-        bricks = components + bases + dependent_components + dependent_bases
         print_detected_changes(bricks, "data", short)
-
         return
 
-    print_detected_changes(components, "comp", short)
-    print_detected_changes(bases, "base", short)
+    print_detected_changes(changed_components, "comp", short)
+    print_detected_changes(changed_bases, "base", short)
 
     if with_deps:
         print_detected_dependent(dependent_bases, dependent_components)

--- a/components/polylith/poetry/commands/diff.py
+++ b/components/polylith/poetry/commands/diff.py
@@ -20,6 +20,11 @@ class DiffCommand(Command):
             flag=True,
         ),
         option(
+            long_name="deps",
+            description="Print bricks that depend on the changes. Use with --bricks.",
+            flag=True,
+        ),
+        option(
             long_name="since",
             description="Changed since a specific tag",
             flag=False,
@@ -28,9 +33,13 @@ class DiffCommand(Command):
 
     def handle(self) -> int:
         since = self.option("since")
-        short = True if self.option("short") else False
-        bricks = True if self.option("bricks") else False
 
-        commands.diff.run(since, short, bricks)
+        options = {
+            "short": self.option("short"),
+            "bricks": self.option("bricks"),
+            "deps": self.option("deps"),
+        }
+
+        commands.diff.run(since, options)
 
         return 0

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.26.2"
+version = "1.27.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.13.2"
+version = "1.14.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/commands/test_diff.py
+++ b/test/components/polylith/commands/test_diff.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from polylith import commands
+
+
+def test_calculate_dependent_bricks(monkeypatch):
+    fake_imports = {
+        "one": {"three"},
+        "two": {"three"},
+        "three": {"four"},
+        "four": {},
+        "base_one": {"one", "four"},
+        "base_two": {"two", "four"},
+    }
+    monkeypatch.setattr(
+        commands.diff, "get_imports", lambda *args, **kwargs: fake_imports
+    )
+
+    projects_data = [
+        {"bases": ["base_one", "base_two"], "components": ["one", "two", "three"]}
+    ]
+
+    changed_bricks = {"one", "three"}
+
+    res = commands.diff.calculate_dependent_bricks(
+        Path.cwd(), "test", projects_data, changed_bricks
+    )
+
+    assert res["bases"] == ["base_one"]
+    assert res["components"] == ["two"]

--- a/test/components/polylith/commands/test_diff.py
+++ b/test/components/polylith/commands/test_diff.py
@@ -26,5 +26,5 @@ def test_calculate_dependent_bricks(monkeypatch):
         Path.cwd(), "test", projects_data, changed_bricks
     )
 
-    assert res["bases"] == ["base_one"]
-    assert res["components"] == ["two"]
+    assert res["bases"] == {"base_one"}
+    assert res["components"] == {"two"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding an option to the `poly diff` command - `--deps` - that can be used in combination with the `--bricks` option.

This will calculate the bricks that are dependent on the changed bricks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will add the possibility to run unit tests based on not only the changed bricks, but also the bricks that could be affected by the changes.

fixes #242 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Local run of poly diff via the CLI
✅ Local install of the Poetry plugin, and running the poly diff command on the python-polylith-example repo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
