### PR TITLE
fix(poly check, poly libs): normalize library name and dist name during  top namespaces lookup

### DIFF
--- a/components/polylith/alias/core.py
+++ b/components/polylith/alias/core.py
@@ -15,10 +15,18 @@ def parse(aliases: List[str]) -> Dict[str, List[str]]:
     return reduce(_to_key_with_values, aliases, {})
 
 
-def pick(aliases: Dict[str, List[str]], keys: Set) -> Set:
-    normalized_keys = {str.lower(k) for k in keys}
+def _normalized_name(name: str) -> str:
+    chars = {"-", "."}
 
-    matrix = [v for k, v in aliases.items() if str.lower(k) in normalized_keys]
+    normalized = reduce(lambda acc, char: str.replace(acc, char, "_"), chars, name)
+
+    return str.lower(normalized)
+
+
+def pick(aliases: Dict[str, List[str]], keys: Set) -> Set:
+    normalized_keys = {_normalized_name(k) for k in keys}
+
+    matrix = [v for k, v in aliases.items() if _normalized_name(k) in normalized_keys]
 
     flattened: List = sum(matrix, [])
 

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.27.1"
+version = "1.27.2"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.14.1"
+version = "1.14.2"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/alias/test_alias.py
+++ b/test/components/polylith/alias/test_alias.py
@@ -59,6 +59,20 @@ def test_pick_aliases_by_case_insensitive_keys():
     assert res == {"cv2", "jinja2", "jwt", "_yaml", "yaml"}
 
 
+def test_pick_aliases_by_keys_using_normalized_names():
+    aliases = {
+        "name_with_underscore": ["with_underscore"],
+        "name-with-hyphen": ["with_hyphen"],
+        "name.something": ["with_dot"],
+    }
+
+    keys = {"name-with-underscore", "name-with-hyphen", "name-something"}
+
+    res = alias.pick(aliases, keys)
+
+    assert res == {"with_underscore", "with_hyphen", "with_dot"}
+
+
 def test_pick_empty_alias_by_keys():
     aliases = {}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Normalizing the third-party library name (found in the pyproject.toml and the lock file) when comparing it to the distribution name (found in the virtual environment), during lookups for top namespaces.

The normalization will replace any hyphens or dots in the name, and replace with an underscore.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Attempting to solve the issue(s) described in #247 

With this Pull Request, it shouldn't be necessary to use the `--alias` option, and the `--strict` option should find matching libraries and imports.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
