### PR TITLE
feat: add support for uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Have a look at the [Python-specific documentation](https://davidvujic.github.io/
 You will find installation, setup, usage guides, examples and more.
 
 ## Python Monorepos with Polylith :snake:
-You can use Polylith with Poetry, Hatch, PDM, Rye and Pantsbuild.
+You can use Polylith with Poetry, Hatch, PDM, Rye, uv and Pantsbuild.
 This repo contains a Poetry plugin, a standalone CLI and build hooks.
 
 * [a Poetry Plugin](https://pypi.org/project/poetry-polylith-plugin)
@@ -51,9 +51,9 @@ This repo contains a Poetry plugin, a standalone CLI and build hooks.
 * [a PDM Build Hook for the workspace](https://pypi.org/project/pdm-polylith-workspace/)
 
 The Poetry plugin adds tooling support to Poetry.
-The CLI adds tooling support for several Package & Dependency Managers (such as Hatch, PDM and Rye).
+The CLI adds tooling support for several Package & Dependency Managers (such as Hatch, PDM, Rye and uv).
 
-The Hatch Build Hook adds build-specific support (also for Rye and Pantsbuild, using hatchling as the build backend).
+The Hatch Build Hook adds build-specific support (also for uv, Rye and Pantsbuild, using hatchling as the build backend).
 The PDM Build Hook for _projects_ adds build-specific support for PDM.
 The PDM Build Hook for the _workspace_ makes the virtual environment aware of the way Polylith organizes code (i.e. the bases and components folders).
 
@@ -64,6 +64,7 @@ There's example Polylith repositories for:
 - [PDM](https://github.com/DavidVujic/python-polylith-example-pdm)
 - [Rye](https://github.com/DavidVujic/python-polylith-example-rye)
 - [Pants](https://github.com/DavidVujic/python-polylith-example-pants)
+- [uv](https://github.com/DavidVujic/python-polylith-example-uv)
 
 The repositories are example __Python__ setups of the Polylith Architecture.
 You will find examples of sharing code between different kind of projects,

--- a/components/polylith/libs/lock_files.py
+++ b/components/polylith/libs/lock_files.py
@@ -5,6 +5,7 @@ from polylith.toml import load_toml
 patterns = {
     "pdm.lock": "toml",
     "poetry.lock": "toml",
+    "uv.lock": "toml",
     "requirements.lock": "text",
     "requirements.txt": "text",
 }

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.27.3"
+version = "1.27.4"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/README.md
+++ b/projects/polylith_cli/README.md
@@ -137,8 +137,25 @@ Create a workspace, with a basic Polylith folder structure.
 rye run poly create workspace --name my_namespace --theme loose
 ```
 
-### Edit the configuration
-The default build backend for Rye is Hatch. Add the `hatch-polylith-bricks` build hook plugin to the `pyproject.toml` file.
+## Setup for uv users
+``` shell
+uv init -name my_repo  # name your repo
+
+cd my_repo
+
+uv add polylith-cli --dev
+
+uv sync  # create a virtual environment and lock files
+```
+
+Create a workspace, with a basic Polylith folder structure.
+
+``` shell
+uv run poly create workspace --name my_namespace --theme loose
+```
+
+### Rye and uv users: edit the configuration
+The default build backend for Rye and uv is Hatch. Add the `hatch-polylith-bricks` build hook plugin to the `pyproject.toml` file.
 
 ``` toml
 [build-system]
@@ -149,35 +166,50 @@ build-backend = "hatchling.build"
 # this section is needed to enable the hook in the build process, even if empty.
 ```
 
-Make Rye (and Hatch) aware of the way Polylith organizes source code:
+Make Rye and uv (and Hatch) aware of the way Polylith organizes source code:
 ``` toml
 [tool.hatch.build]
 dev-mode-dirs = ["components", "bases", "development", "."]
 ```
 
-Remove the `[project.scripts]` and `[tool.hatch.build.targets.wheel]` sections.
-
 Run the `sync` command to update the virtual environment:
 
+
+Rye:
 ``` shell
 rye sync
 ```
 
-Finally, remove the `src` boilerplate code that was added by Rye in the first step:
+uv:
+``` shell
+uv sync
+```
+
+Finally, remove the `src` boilerplate code that was added by Rye and uv in the first step:
 ``` shell
 rm -r src
 ```
 
-### Ready for coding!
+### Rye and uv users: ready for coding!
 
 Add components, bases and projects:
 
+Rye:
 ``` shell
 rye run poly create component --name my_component
 
 rye run poly create base --name my_example_endpoint
 
 rye run poly create project --name my_example_project
+```
+
+uv:
+``` shell
+uv run poly create component --name my_component
+
+uv run poly create base --name my_example_endpoint
+
+uv run poly create project --name my_example_project
 ```
 
 For details, have a look at the [documentation](https://davidvujic.github.io/python-polylith-docs/).

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.14.3"
+version = "1.15.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/libs/test_parse_lock_file.py
+++ b/test/components/polylith/libs/test_parse_lock_file.py
@@ -23,11 +23,13 @@ expected_libraries = {
 pdm_lock_file = "pdm"
 piptools_lock_file = "piptools"
 rye_lock_file = "rye"
+uv_lock_file = "uv"
 
 test_lock_files = {
     pdm_lock_file: "toml",
     piptools_lock_file: "text",
     rye_lock_file: "text",
+    uv_lock_file: "toml",
 }
 
 
@@ -63,5 +65,11 @@ def test_parse_contents_of_pdm_lock_file(setup):
 
 def test_parse_contents_of_pip_tools_lock_file(setup):
     names = lock_files.extract_libs(project_data, piptools_lock_file, "text")
+
+    assert names == expected_libraries
+
+
+def test_parse_contents_of_uv_lock_file(setup):
+    names = lock_files.extract_libs(project_data, uv_lock_file, "toml")
 
     assert names == expected_libraries

--- a/test/test_data/uv
+++ b/test/test_data/uv
@@ -1,0 +1,55 @@
+version = 1
+requires-python = ">=3.8"
+environment-markers = [
+    "python_full_version < '3.13'",
+    "python_full_version >= '3.13'",
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+
+
+[[package]]
+name = "anyio"
+version = "4.4.0"
+
+[[package]]
+name = "click"
+version = "8.1.7"
+
+[[package]]
+name = "fastapi"
+version = "0.109.2"
+
+[[package]]
+name = "h11"
+version = "0.14.0"
+
+[[package]]
+name = "idna"
+version = "3.7"
+
+[[package]]
+name = "pydantic"
+version = "2.7.4"
+
+[[package]]
+name = "pydantic-core"
+version = "2.18.4"
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+
+[[package]]
+name = "starlette"
+version = "0.36.3"
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+
+[[package]]
+name = "uvicorn"
+version = "0.25.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding support for `uv`. 

`uv` is using the same build backend as `Rye` and the Polylith tool already works out of the box. The changes in this Pull Request is adding ability to read the uv-specific lock files called `uv.lock`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To support as many Package & Dependency management tools as possible and reasonable. `uv` is a new (and experimental) tool, with interesting features and project goals.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ unit test
✅ adding a new example project: python-polylith-example-uv.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
