### PR TITLE
fix(projects): allow optional authors and description

### DIFF
--- a/components/polylith/project/create.py
+++ b/components/polylith/project/create.py
@@ -18,12 +18,15 @@ def create_project(path: Path, template: str, name: str, description: str) -> No
     authors = repo.get_authors(path)
     python_version = repo.get_python_version(path)
 
+    description_field = f'description = "{description}"' if description else ""
+    authors_field = f"authors = {authors}" if authors else ""
+
     project_toml = create_project_toml(
         template,
         {
             "name": name,
-            "description": description,
-            "authors": authors,
+            "description": description_field,
+            "authors": authors_field,
             "python_version": python_version,
         },
     )

--- a/components/polylith/project/templates.py
+++ b/components/polylith/project/templates.py
@@ -2,8 +2,8 @@ poetry_pyproject = """\
 [tool.poetry]
 name = "{name}"
 version = "0.1.0"
-description = "{description}"
-authors = {authors}
+{description}
+{authors}
 license = ""
 
 packages = []
@@ -24,8 +24,8 @@ build-backend = "hatchling.build"
 [project]
 name = "{name}"
 version = "0.1.0"
-description = "{description}"
-authors = {authors}
+{description}
+{authors}
 
 requires-python = "{python_version}"
 
@@ -44,8 +44,8 @@ build-backend = "pdm.backend"
 [project]
 name = "{name}"
 version = "0.1.0"
-description = "{description}"
-authors = {authors}
+{description}
+{authors}
 
 requires-python = "{python_version}"
 

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.27.5"
+version = "1.27.6"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.15.1"
+version = "1.15.2"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/project/test_templates.py
+++ b/test/components/polylith/project/test_templates.py
@@ -4,8 +4,8 @@ from polylith.project import templates
 
 template_data = {
     "name": "a project",
-    "description": "a description",
-    "authors": [],
+    "description": "",
+    "authors": "",
     "python_version": "3.12",
 }
 
@@ -14,6 +14,25 @@ def test_poetry_template():
     data = tomlkit.loads(templates.poetry_pyproject.format(**template_data))
 
     assert data["tool"]["poetry"] is not None
+    assert data["tool"]["poetry"].get("authors") is None
+    assert data["tool"]["poetry"].get("description") is None
+
+
+def test_poetry_template_with_optionals():
+    expected_description = "Hello world"
+    expected_authors = ["Unit test"]
+
+    description_field = f'description = "{expected_description}"'
+    authors_field = f"authors = {expected_authors}"
+
+    with_optionals = {
+        **template_data,
+        **{"description": description_field, "authors": authors_field},
+    }
+    data = tomlkit.loads(templates.poetry_pyproject.format(**with_optionals))
+
+    assert data["tool"]["poetry"]["description"] == expected_description
+    assert data["tool"]["poetry"]["authors"] == expected_authors
 
 
 def test_hatch_template():
@@ -23,9 +42,47 @@ def test_hatch_template():
     assert data["tool"]["hatch"]["build"]["hooks"]["polylith-bricks"] == {}
     assert data["tool"]["polylith"]["bricks"] == {}
 
+    assert data["project"].get("description") is None
+    assert data["project"].get("authors") is None
+
+
+def test_hatch_template_with_optionals():
+    expected_description = "Hello world"
+
+    description_field = f'description = "{expected_description}"'
+    authors_field = 'authors = [{ name = "Unit Test"}]'
+
+    with_optionals = {
+        **template_data,
+        **{"description": description_field, "authors": authors_field},
+    }
+    data = tomlkit.loads(templates.hatch_pyproject.format(**with_optionals))
+
+    assert data["project"]["description"] == expected_description
+    assert data["project"]["authors"] == [{"name": "Unit Test"}]
+
 
 def test_pdm_template():
     data = tomlkit.loads(templates.pdm_pyproject.format(**template_data))
 
     assert "pdm-polylith-bricks" in data["build-system"]["requires"]
     assert data["tool"]["polylith"]["bricks"] == {}
+
+    assert data["project"].get("description") is None
+    assert data["project"].get("authors") is None
+
+
+def test_pdm_template_with_optionals():
+    expected_description = "Hello world"
+
+    description_field = f'description = "{expected_description}"'
+    authors_field = 'authors = [{ name = "Unit Test"}]'
+
+    with_optionals = {
+        **template_data,
+        **{"description": description_field, "authors": authors_field},
+    }
+    data = tomlkit.loads(templates.pdm_pyproject.format(**with_optionals))
+
+    assert data["project"]["description"] == expected_description
+    assert data["project"]["authors"] == [{"name": "Unit Test"}]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allowing optional project `description` and `authors` when creating a project-specific `pyproject.toml` file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To avoid forcing users to add these fields to the workspace `pyproject.toml`. Currently, the `poly create project` command will fail if the `authors` field is missing. I discovered that `uv` by default doesn't add the `authors` field when creating a new project.

fixes #259 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Unit test
✅ Local run of Poetry plugin and CLI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
