### PR TITLE
feat(poly diff): allow diff with commit hashes

### DIFF
--- a/components/polylith/commands/diff.py
+++ b/components/polylith/commands/diff.py
@@ -99,10 +99,10 @@ def print_views(root: Path, tag: str, options: dict) -> None:
 def run(tag_name: Union[str, None], options: dict):
     root = repo.get_workspace_root(Path.cwd())
 
-    tag = diff.collect.get_latest_tag(root, tag_name)
+    tag = diff.collect.get_latest_tag(root, tag_name) or tag_name
 
     if not tag:
-        print("No tags found in repository.")
+        print("No matching tags or commits found in repository.")
         return
 
     print_views(root, tag, options)

--- a/components/polylith/configuration/core.py
+++ b/components/polylith/configuration/core.py
@@ -29,12 +29,15 @@ def get_git_tag_pattern(toml: dict) -> str:
     return toml["tool"]["polylith"]["git_tag_pattern"]
 
 
-def get_tag_pattern_from_config(path: Path, key: Union[str, None]) -> str:
+def get_tag_pattern_from_config(path: Path, key: Union[str, None]) -> Union[str, None]:
     toml: dict = _load_workspace_config(path)
 
     patterns = toml["tool"]["polylith"].get("tag", {}).get("patterns")
 
-    return patterns[key or "stable"] if patterns else get_git_tag_pattern(toml)
+    if not key:
+        return patterns["stable"] if patterns else get_git_tag_pattern(toml)
+
+    return patterns.get(key)
 
 
 def get_tag_sort_options_from_config(path: Path) -> List[str]:

--- a/components/polylith/diff/collect.py
+++ b/components/polylith/diff/collect.py
@@ -58,6 +58,10 @@ def get_changed_projects(changed_files: List[Path]) -> list:
 
 def get_latest_tag(root: Path, key: Union[str, None]) -> Union[str, None]:
     tag_pattern = configuration.get_tag_pattern_from_config(root, key)
+
+    if not tag_pattern:
+        return None
+
     sorting_options = [
         f"--sort={option}"
         for option in configuration.get_tag_sort_options_from_config(root)

--- a/components/polylith/diff/report.py
+++ b/components/polylith/diff/report.py
@@ -86,7 +86,7 @@ def print_projects_affected_by_changes(projects: Set[str], short: bool) -> None:
 def print_diff_summary(tag: str, bases: List[str], components: List[str]) -> None:
     console = Console(theme=theme.poly_theme)
 
-    console.print(Padding(f"[data]Diff: based on the {tag} tag[/]", (1, 0, 1, 0)))
+    console.print(Padding(f"[data]Diff: based on {tag}[/]", (1, 0, 1, 0)))
 
     if not bases and not components:
         console.print("[data]No brick changes found.[/]")

--- a/projects/pdm_polylith_bricks/pyproject.toml
+++ b/projects/pdm_polylith_bricks/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdm-polylith-bricks"
-version = "1.0.7"
+version = "1.0.8"
 description = "a PDM build hook for Polylith"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/pdm_polylith_workspace/pyproject.toml
+++ b/projects/pdm_polylith_workspace/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdm-polylith-workspace"
-version = "1.0.7"
+version = "1.0.8"
 description = "a PDM build hook for a Polylith workspace"
 homepage = "https://davidvujic.github.io/python-polylith-docs/"
 repository = "https://github.com/davidvujic/python-polylith"

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.28.0"
+version = "1.29.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.16.0"
+version = "1.17.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/configuration/test_core.py
+++ b/test/components/polylith/configuration/test_core.py
@@ -74,6 +74,8 @@ def test_get_tag_pattern(use_loose):
     assert stable == "stable-*"
     assert release == "v[0-9]*"
 
+    assert core.get_tag_pattern_from_config(fake_path, "non_existing_tag") is None
+
 
 def test_get_tag_sort_options_from_config(use_loose):
     options = core.get_tag_sort_options_from_config(fake_path)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allowing `poly diff` with a commit hash (by using the already existing `--since` option).

This also enables running the `poly diff --since` with a specific tag name, and not only the pre-defined pattern from the workspace configuration.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #264 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Unit test
✅ Local run of the `poly diff` command

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
