### PR TITLE
feat(poly check, poly libs): use strict mode when dependencies origin from lock file

### DIFF
--- a/components/polylith/commands/check.py
+++ b/components/polylith/commands/check.py
@@ -55,16 +55,21 @@ def run(root: Path, ns: str, project_data: dict, options: dict) -> bool:
     deps = project_data["deps"]
     alias = options["alias"]
 
+    from_lock_file = libs.is_from_lock_file(deps)
+
     collected_imports = check.report.collect_all_imports(root, ns, project_data)
     collected_libs = distributions.known_aliases_and_sub_dependencies(
-        deps, alias, options
+        deps,
+        alias,
+        options,
+        from_lock_file,
     )
 
     details = check.report.create_report(
         project_data,
         collected_imports,
         collected_libs,
-        is_strict,
+        is_strict or from_lock_file,
     )
 
     res = all([not details["brick_diff"], not details["libs_diff"]])

--- a/components/polylith/commands/libs.py
+++ b/components/polylith/commands/libs.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import List, Set
 
 from polylith import distributions
-from polylith.libs import report
+from polylith.libs import is_from_lock_file, report
 
 
 def missing_libs(project_data: dict, imports: dict, options: dict) -> bool:
@@ -15,15 +15,17 @@ def missing_libs(project_data: dict, imports: dict, options: dict) -> bool:
 
     brick_imports = imports[name]
 
+    from_lock_file = is_from_lock_file(deps)
+
     libs = distributions.known_aliases_and_sub_dependencies(
-        deps, library_alias, options
+        deps, library_alias, options, from_lock_file
     )
 
     return report.print_missing_installed_libs(
         brick_imports,
         libs,
         name,
-        is_strict,
+        is_strict or from_lock_file,
     )
 
 

--- a/components/polylith/distributions/collect.py
+++ b/components/polylith/distributions/collect.py
@@ -30,7 +30,7 @@ def extract_library_names(deps: dict) -> Set[str]:
 
 
 def known_aliases_and_sub_dependencies(
-    deps: dict, library_alias: list, options: dict
+    deps: dict, library_alias: list, options: dict, from_lock_file: bool,
 ) -> Set[str]:
     """Collect known aliases (packages) for third-party libraries.
 
@@ -38,7 +38,6 @@ def known_aliases_and_sub_dependencies(
     collect sub-dependencies and distribution top-namespace for each library, and append to the result.
     """
 
-    lock_file = any(str.endswith(deps["source"], s) for s in {".lock", ".txt"})
     third_party_libs = extract_library_names(deps)
 
     fn = options.get("dists_fn", get_distributions)
@@ -46,7 +45,7 @@ def known_aliases_and_sub_dependencies(
 
     dist_packages = distributions_packages(dists)
     custom_aliases = alias.parse(library_alias)
-    sub_deps = distributions_sub_packages(dists) if not lock_file else {}
+    sub_deps = distributions_sub_packages(dists) if not from_lock_file else {}
 
     a = alias.pick(dist_packages, third_party_libs)
     b = alias.pick(custom_aliases, third_party_libs)

--- a/components/polylith/libs/__init__.py
+++ b/components/polylith/libs/__init__.py
@@ -1,11 +1,12 @@
 from polylith.libs import report
 from polylith.libs.grouping import extract_third_party_imports, get_third_party_imports
-from polylith.libs.lock_files import extract_libs, pick_lock_file
+from polylith.libs.lock_files import extract_libs, is_from_lock_file, pick_lock_file
 
 __all__ = [
     "report",
     "extract_third_party_imports",
     "get_third_party_imports",
     "extract_libs",
+    "is_from_lock_file",
     "pick_lock_file",
 ]

--- a/components/polylith/libs/lock_files.py
+++ b/components/polylith/libs/lock_files.py
@@ -71,3 +71,7 @@ def extract_libs(project_data: dict, filename: str, filetype: str) -> dict:
         return extract_lib_names_from_txt(path)
     except (IndexError, KeyError, ValueError) as e:
         raise ValueError(f"Failed reading {filename}: {repr(e)}") from e
+
+
+def is_from_lock_file(deps: dict) -> bool:
+    return any(deps["source"] == s for s in set(patterns.keys()))

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.29.0"
+version = "1.30.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.17.0"
+version = "1.18.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/distributions/test_collect.py
+++ b/test/components/polylith/distributions/test_collect.py
@@ -38,7 +38,7 @@ def test_collect_known_aliases_and_sub_dependencies():
 
     fake_alias = ["hello-world-library=hello"]
 
-    res = collect.known_aliases_and_sub_dependencies(fake_deps, fake_alias, {})
+    res = collect.known_aliases_and_sub_dependencies(fake_deps, fake_alias, {}, False)
 
     assert "typer" in res
     assert "typing-extensions" in res


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Run `poly check` and `poly libs` in strict mode when the collected third-party depencencies is collected from a lock-file. 
This will have the same effect as when running the commands with the `--strict` option.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #267 and the issue decribed in #266 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Local run of `poly check` and `poly libs`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
