### PR TITLE
fix: Normalize uv workspace member names before lookup

### DIFF
--- a/components/polylith/libs/lock_files.py
+++ b/components/polylith/libs/lock_files.py
@@ -1,3 +1,4 @@
+from functools import reduce
 from pathlib import Path
 from typing import List
 
@@ -93,6 +94,14 @@ def pick_packages(data: dict, name: str) -> list:
     return [package] + flattened if flattened else [package]
 
 
+def normalized(name: str) -> str:
+    chars = {"_", "."}
+
+    normalized = reduce(lambda acc, char: str.replace(acc, char, "-"), chars, name)
+
+    return str.lower(normalized)
+
+
 def extract_workspace_member_libs(
     root: Path,
     project_data: dict,
@@ -109,7 +118,7 @@ def extract_workspace_member_libs(
 
     data = load_toml(path)
     members = data.get("manifest", {}).get("members", [])
-    member_name = project_data["name"]
+    member_name = normalized(project_data["name"])
 
     if member_name not in members:
         return {}

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.30.1"
+version = "1.30.2"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.19.0"
+version = "1.19.1"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/libs/test_parse_lock_file.py
+++ b/test/components/polylith/libs/test_parse_lock_file.py
@@ -115,7 +115,13 @@ def test_parse_contents_of_uv_workspaces_aware_lock_file(setup):
     aws_lambda_libs = _extract_workspace_member_libs("my-aws-lambda-project")
     non_existing = _extract_workspace_member_libs("this-workspace-member-doesnt-exist")
 
+    gcp_libs_from_normalized_name = _extract_workspace_member_libs(
+        "my_gcp_Function-project"
+    )
+
     assert gcp_libs == expected_gcp_libs
     assert consumer_libs == expected_consumer_libs
     assert aws_lambda_libs == {}
     assert non_existing == {}
+
+    assert gcp_libs_from_normalized_name == expected_gcp_libs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Normalize the name that is specified in the project `pyproject.toml` files, before the member lookup in the `uv.lock` file.

This, because the uv tool list workspace member name without `_`, `.` and all in lower case.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing the problem that the library dependencies won't be found when the project name contains any of the characters above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
