### PR TITLE
fix(uv workspaces): check if the root lock-file is workspace enabled before picking member dependencies

### DIFF
--- a/components/polylith/commands/check.py
+++ b/components/polylith/commands/check.py
@@ -27,12 +27,12 @@ def extract_libs_from_workspace_lock_file(root: Path, project_data: dict) -> dic
     filename = lock_file_data["filename"]
     filetype = lock_file_data["filetype"]
 
-    third_party_libs = libs.extract_workspace_member_libs(
-        root,
-        project_data,
-        filename,
-        filetype,
-    )
+    data = libs.get_workspace_enabled_lock_file_data(root, filename, filetype)
+
+    if not data:
+        return {}
+
+    third_party_libs = libs.extract_workspace_member_libs(data, project_data)
 
     return {"deps": {"items": third_party_libs, "source": filename}}
 

--- a/components/polylith/libs/__init__.py
+++ b/components/polylith/libs/__init__.py
@@ -3,6 +3,7 @@ from polylith.libs.grouping import extract_third_party_imports, get_third_party_
 from polylith.libs.lock_files import (
     extract_libs,
     extract_workspace_member_libs,
+    get_workspace_enabled_lock_file_data,
     is_from_lock_file,
     pick_lock_file,
 )
@@ -13,6 +14,7 @@ __all__ = [
     "get_third_party_imports",
     "extract_libs",
     "extract_workspace_member_libs",
+    "get_workspace_enabled_lock_file_data",
     "is_from_lock_file",
     "pick_lock_file",
 ]

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.30.2"
+version = "1.30.3"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.19.1"
+version = "1.19.2"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/libs/test_parse_lock_file.py
+++ b/test/components/polylith/libs/test_parse_lock_file.py
@@ -79,12 +79,15 @@ def test_parse_contents_of_uv_lock_file(setup):
 
 
 def _extract_workspace_member_libs(name: str) -> dict:
-    data = {**project_data, **{"name": name}}
+    data = lock_files.get_workspace_enabled_lock_file_data(
+        test_path, uv_workspace_lock_file, "toml"
+    )
+
+    extended_project_data = {**project_data, **{"name": name}}
+
     return lock_files.extract_workspace_member_libs(
-        test_path,
         data,
-        uv_workspace_lock_file,
-        "toml",
+        extended_project_data,
     )
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Check if the root lock-file is workspace enabled, before trying to find member dependencies.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To fallback to the other ways of dependency and distribution data lookups if not found any workspace member data.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Unit test
✅ Local run of commands

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
