### PR TITLE
fix(cli): typo in the poly sync annotation for the --verbose option (BREAKING)

### DIFF
--- a/bases/polylith/cli/core.py
+++ b/bases/polylith/cli/core.py
@@ -132,7 +132,7 @@ def sync_command(
     strict: Annotated[bool, options.strict] = False,
     quiet: Annotated[bool, options.quiet] = False,
     directory: Annotated[str, options.directory] = "",
-    verbose: Annotated[str, options.verbose] = "",
+    verbose: Annotated[bool, options.verbose] = False,
 ):
     """Update pyproject.toml with missing bricks."""
     root = repo.get_workspace_root(Path.cwd())

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.19.2"
+version = "1.20.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changing the data type from `str` to `bool` for the `--verbose` option.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `str` annotation is a typo, the option is meant to be a boolean just like in other commands.

NOTE: this will be a __breaking__ change, for any users using the `poly sync --verbose` option today. My appologies if this is the case 🙏 . Hopefully this will be a minor thing to adjust (i.e. just use `--verbose` without any string value).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Manual run of the `poly sync` command from the CLI endpoint.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
