### PR TITLE
fix(poly check): verbose output without duplication

### DIFF
--- a/bases/polylith/cli/core.py
+++ b/bases/polylith/cli/core.py
@@ -74,12 +74,12 @@ def check_command(
     filtered_projects = filtered_projects_data(only_projects_data, directory)
     enriched_projects = enriched_with_lock_files_data(root, filtered_projects, verbose)
 
-    results = {commands.check.run(root, ns, p, cli_options) for p in enriched_projects}
+    result = commands.check.run(root, ns, enriched_projects, cli_options)
     libs_result = commands.check.check_libs_versions(
         filtered_projects, all_projects_data, cli_options
     )
 
-    if not all(results) or not libs_result:
+    if not result or not libs_result:
         raise Exit(code=1)
 
 

--- a/components/polylith/check/report.py
+++ b/components/polylith/check/report.py
@@ -7,10 +7,11 @@ from polylith.reporting import theme
 from rich.console import Console
 
 
-def _print_imports(bricks: dict) -> None:
+def _print_imports(bricks: dict, brick_type: str) -> None:
     console = Console(theme=theme.poly_theme)
 
     items = sorted(bricks.items())
+    tag = "base" if brick_type == "bases" else "comp"
 
     for item in items:
         key, values = item
@@ -21,7 +22,7 @@ def _print_imports(bricks: dict) -> None:
             continue
 
         joined = ", ".join(sorted(imports_in_brick))
-        message = f":information: [data]{key}[/] is importing [data]{joined}[/]"
+        message = f":information: [{tag}]{key}[/] is importing [data]{joined}[/]"
         console.print(message)
 
 
@@ -29,8 +30,8 @@ def print_brick_imports(brick_imports: dict) -> None:
     bases = brick_imports["bases"]
     components = brick_imports["components"]
 
-    _print_imports(bases)
-    _print_imports(components)
+    _print_imports(bases, "bases")
+    _print_imports(components, "components")
 
 
 def print_missing_deps(diff: Set[str], project_name: str) -> None:

--- a/components/polylith/commands/check.py
+++ b/components/polylith/commands/check.py
@@ -109,8 +109,15 @@ def run_each(
     return res, details
 
 
+def _merge(data: List[dict], key: str) -> dict:
+    return reduce(lambda acc, d: {**acc, **d[key]}, data, {})
+
+
 def _print_brick_imports(all_imports: List[dict]) -> None:
-    merged: dict = reduce(lambda acc, data: {**acc, **data}, all_imports, {})
+    merged_bases = _merge(all_imports, "bases")
+    merged_components = _merge(all_imports, "components")
+
+    merged = {"bases": merged_bases, "components": merged_components}
 
     check.report.print_brick_imports(merged)
 

--- a/components/polylith/commands/check.py
+++ b/components/polylith/commands/check.py
@@ -123,16 +123,15 @@ def _print_brick_imports(all_imports: List[dict]) -> None:
 
 
 def run(root: Path, ns: str, projects_data: List[dict], options: dict) -> bool:
-    res = [run_each(root, ns, p, options) for p in projects_data]
-
-    run_result = [r[0] for r in res]
-    brick_imports = [r[1]["brick_imports"] for r in res]
-    third_party_imports = [r[1]["third_party_imports"] for r in res]
-
     is_verbose = options["verbose"] and not options["quiet"]
+    res = [run_each(root, ns, p, options) for p in projects_data]
+    results = [r[0] for r in res]
 
     if is_verbose:
+        brick_imports = [r[1]["brick_imports"] for r in res]
+        third_party_imports = [r[1]["third_party_imports"] for r in res]
+
         _print_brick_imports(brick_imports)
         _print_brick_imports(third_party_imports)
 
-    return all(run_result)
+    return all(results)

--- a/components/polylith/poetry/commands/check.py
+++ b/components/polylith/poetry/commands/check.py
@@ -63,12 +63,10 @@ class CheckCommand(Command):
             self.merged_project_data(data) for data in projects_data
         ]
 
-        results = {
-            commands.check.run(root, ns, data, options) for data in merged_projects_data
-        }
+        result = commands.check.run(root, ns, merged_projects_data, options)
 
         libs_result = commands.check.check_libs_versions(
             projects_data, all_projects_data, options
         )
 
-        return 0 if all(results) and libs_result else 1
+        return 0 if result and libs_result else 1

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.32.0"
+version = "1.33.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.21.0"
+version = "1.22.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixing the output from the `poly check --verbose` command. Currently, there are duplicated content for each project (that's a bug) and the imports are repeated for all projects sharing the same bricks. The output should be one collection of bricks and their imports. I have kept the separation of imported bricks and imported third-party libraries.

__Before__
(example from the Polylith repo itself, and the CLI project)
<img width="400" alt="before" src="https://github.com/user-attachments/assets/b6461382-a585-4ff6-9f03-324f02217482">
olylith repo and the CLI project):

__After__
<img width="400" alt="after" src="https://github.com/user-attachments/assets/43f32411-d1ad-4d61-8681-4f12dceca962">


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #291 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Local run of CLI command
✅ Local install of the Poetry plugin

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
