### PR TITLE
fix: Hatchling dev-mode and editable installations

### DIFF
--- a/components/polylith/hatch/hooks/bricks.py
+++ b/components/polylith/hatch/hooks/bricks.py
@@ -1,22 +1,49 @@
 import shutil
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from polylith import parsing, repo, toml
 from polylith.hatch import core
 
 
+def get_build_section(data: dict) -> dict:
+    return data.get("tool", {}).get("hatch", {}).get("build", {})
+
+
+def is_in_path(key: str, paths: List[str]) -> bool:
+    return any(key.startswith(p) for p in paths)
+
+
+def filter_dev_mode_bricks(data: dict, bricks: dict) -> dict:
+    build_section = get_build_section(data)
+    dev_mode_dirs = build_section.get("dev-mode-dirs")
+
+    if not dev_mode_dirs:
+        return bricks
+
+    return {k: v for k, v in bricks.items() if not is_in_path(k, dev_mode_dirs)}
+
+
+def filtered_bricks(data: dict, version: str) -> dict:
+    bricks = toml.get_project_packages_from_polylith_section(data)
+
+    if version == "editable":
+        return filter_dev_mode_bricks(data, bricks)
+
+    return bricks
+
+
 class PolylithBricksHook(BuildHookInterface):
     PLUGIN_NAME = "polylith-bricks"
 
     def initialize(self, version: str, build_data: Dict[str, Any]) -> None:
-        include_key = "force_include_editable" if version == "editable" else "force_include"
+        include_key = "force_include"
         root = self.root
         pyproject = Path(f"{root}/{repo.default_toml}")
 
         data = toml.read_toml_document(pyproject)
-        bricks = toml.get_project_packages_from_polylith_section(data)
+        bricks = filtered_bricks(data, version)
         found_bricks = {k: v for k, v in bricks.items() if Path(f"{root}/{k}").exists()}
 
         if not bricks or not found_bricks:

--- a/projects/hatch_polylith_bricks/pyproject.toml
+++ b/projects/hatch_polylith_bricks/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatch-polylith-bricks"
-version = "1.3.0"
+version = "1.3.1"
 description = "Hatch build hook plugin for Polylith"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/hatch/test_hook.py
+++ b/test/components/polylith/hatch/test_hook.py
@@ -1,0 +1,41 @@
+import tomlkit
+from polylith.hatch.hooks.bricks import filtered_bricks
+
+project_toml = """\
+[tool.polylith.bricks]
+"../../bases/unittest/one" = "unittest/one"
+"../../components/unittest/two" = "unittest/two"
+"""
+
+project_toml_dev_mode = """\
+[tool.hatch.build]
+dev-mode-dirs = ["../../components", "../../bases"]
+
+[tool.polylith.bricks]
+"../../bases/unittest/one" = "unittest/one"
+"../../components/unittest/two" = "unittest/two"
+"""
+
+
+def test_filtered_bricks():
+    data = tomlkit.loads(project_toml)
+
+    expected = data["tool"]["polylith"]["bricks"]
+
+    first = filtered_bricks(data, version="standard")
+    second = filtered_bricks(data, version="editable")
+
+    assert first == expected
+    assert second == expected
+
+
+def test_filtered_bricks_in_project_with_dev_mode_dirs():
+    data = tomlkit.loads(project_toml_dev_mode)
+
+    expected = data["tool"]["polylith"]["bricks"]
+
+    first = filtered_bricks(data, version="standard")
+    second = filtered_bricks(data, version="editable")
+
+    assert first == expected
+    assert second == {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes an issue with the Hatch build hook, as described in #307 and in a special use case described in #302

Solution:
filter the project-specific bricks when installed in _editable_ mode (i.e. `uv sync` or `hatch env create`) and when using the Hatch-specific `dev-mode-dirs`. Any paths matching the added bricks will be filtered. This will make it possible to create a virtual environment in dev-mode, without adding any bricks to the environment. This will solve the special use case described in #302.

The "editable" mode will be used only when in combination with the dev-mode-dirs, and this should solve the issue #307.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #307 
fixes #302 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ unit test
✅ Local install of the Hatch hook and running `uv sync` with different configs (dev-mode, no dev-mode)
✅ Local install of the Hatch hook and running `hatch env create` with different configs (dev-mode, no dev-mode)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) (in previous deploy, partially broken #306)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
