### PR TITLE
feat(poly): display help page in case of missing arguments (#333)

### DIFF
--- a/bases/polylith/cli/core.py
+++ b/bases/polylith/cli/core.py
@@ -6,7 +6,7 @@ from polylith.cli import build, create, options, test
 from typer import Exit, Option, Typer
 from typing_extensions import Annotated
 
-app = Typer()
+app = Typer(no_args_is_help=True)
 
 app.add_typer(
     create.app,


### PR DESCRIPTION
This PR sets the `Typer` option `no_args_is_help=True`, so that in case of missing arguments the help text is displayed instead of an error.

Resolves #333.

## How Has This Been Tested?

Interactively by running `poly` without any arguments.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
