### PR TITLE
fix(poly check): dependency/dists lookup lookup performance improvements

### DIFF
--- a/components/polylith/distributions/__init__.py
+++ b/components/polylith/distributions/__init__.py
@@ -1,3 +1,4 @@
+from polylith.distributions import caching
 from polylith.distributions.collect import known_aliases_and_sub_dependencies
 from polylith.distributions.core import (
     distributions_packages,
@@ -6,6 +7,7 @@ from polylith.distributions.core import (
 )
 
 __all__ = [
+    "caching",
     "distributions_packages",
     "distributions_sub_packages",
     "get_distributions",

--- a/components/polylith/distributions/caching.py
+++ b/components/polylith/distributions/caching.py
@@ -1,0 +1,17 @@
+_cache = {}
+
+
+def add(key: str, value) -> None:
+    _cache[key] = value
+
+
+def get(key: str):
+    return _cache[key]
+
+
+def exists(key: str) -> bool:
+    return key in _cache
+
+
+def clear() -> None:
+    _cache.clear()

--- a/components/polylith/distributions/core.py
+++ b/components/polylith/distributions/core.py
@@ -83,6 +83,14 @@ def get_distributions() -> list:
     return list(importlib.metadata.distributions())
 
 
+@lru_cache
+def _get_package_dists() -> dict:
+    # added in Python 3.10
+    fn = getattr(importlib.metadata, "packages_distributions", None)
+
+    return fn() if fn else {}
+
+
 def get_packages_distributions(project_dependencies: set) -> set:
     """Return the mapped top namespace from an import
 
@@ -93,10 +101,7 @@ def get_packages_distributions(project_dependencies: set) -> set:
     Note: available for Python >= 3.10
     """
 
-    # added in Python 3.10
-    fn = getattr(importlib.metadata, "packages_distributions", None)
-
-    dists = fn() if fn else {}
+    dists = _get_package_dists()
 
     common = {k for k, v in dists.items() if project_dependencies.intersection(set(v))}
 

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.38.1"
+version = "1.38.2"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.31.2"
+version = "1.31.3"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/distributions/test_core.py
+++ b/test/components/polylith/distributions/test_core.py
@@ -21,6 +21,12 @@ class FakeDist:
         return self.read_text_data
 
 
+@pytest.fixture
+def setup():
+    distributions.caching.clear()
+    distributions.core.package_distributions_from_importlib.cache_clear()
+
+
 def test_distribution_packages():
     dists = list(importlib.metadata.distributions())
 
@@ -61,7 +67,7 @@ def test_distribution_packages_for_missing_metadata_is_handled():
     assert res == {}
 
 
-def test_distribution_packages_with_top_level_ns_information_in_files():
+def test_distribution_packages_with_top_level_ns_information_in_files(setup):
     files = [
         importlib.metadata.PackagePath("some_module.py"),
         importlib.metadata.PackagePath("hello/world.py"),
@@ -104,7 +110,7 @@ def test_distribution_sub_packages():
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
-def test_package_distributions_returning_top_namespace(monkeypatch):
+def test_package_distributions_returning_top_namespace(setup, monkeypatch):
     fake_dists = {
         "something": ["something-subnamespace"],
         "opentelemetry": ["opentelemetry-instrumentation-fastapi"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Improving the performance of the `poly check` command, when doing _dists_ lookups.

This should make the command faster.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Distribution lookups (via the `importlib` builtin) are expensive from a performance perspective. The metadata and `files` fetching is performing I/O actions. In this PR: caching any already performed lookups for a specific distribution (by the dist name).
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Local run on a large Polylith monorepo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
