### PR TITLE
feat(poly create project): interactively suggest base and components to add

### DIFF
--- a/bases/polylith/cli/create.py
+++ b/bases/polylith/cli/create.py
@@ -52,6 +52,8 @@ def project_command(
     """Creates a Polylith project."""
     create(name, description, _create_project)
 
+    project.interactive.run(name)
+
 
 @app.command("workspace")
 def workspace_command(

--- a/components/polylith/commands/sync.py
+++ b/components/polylith/commands/sync.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from polylith import info
 from polylith import sync
 
 
@@ -8,11 +7,7 @@ def run(root: Path, ns: str, project_data: dict, options: dict):
     is_quiet = options["quiet"]
     is_verbose = options["verbose"]
 
-    bases = info.get_bases(root, ns)
-    components = info.get_components(root, ns)
-    workspace_data = {"bases": bases, "components": components}
-
-    diff = sync.calculate_diff(root, ns, project_data, workspace_data)
+    diff = sync.calculate_diff(root, ns, project_data)
 
     sync.update_project(root, ns, diff)
 

--- a/components/polylith/info/__init__.py
+++ b/components/polylith/info/__init__.py
@@ -1,4 +1,5 @@
 from polylith.info.collect import (
+    find_unused_bases,
     get_bases,
     get_bricks_in_projects,
     get_components,
@@ -12,6 +13,7 @@ from polylith.info.report import (
 )
 
 __all__ = [
+    "find_unused_bases",
     "get_bases",
     "get_bricks_in_projects",
     "get_components",

--- a/components/polylith/info/collect.py
+++ b/components/polylith/info/collect.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List
+from typing import List, Set
 
 from polylith.bricks import base, component
 from polylith.project import get_packages_for_projects, parse_package_paths
@@ -53,3 +53,12 @@ def get_projects_data(root: Path, ns: str) -> List[dict]:
     components = get_components(root, ns)
 
     return get_bricks_in_projects(root, components, bases, ns)
+
+
+def find_unused_bases(root: Path, ns: str) -> Set[str]:
+    projects_data = get_projects_data(root, ns)
+
+    bases = get_bases(root, ns)
+    bases_in_projects = set().union(*[p["bases"] for p in projects_data])
+
+    return set(bases).difference(bases_in_projects)

--- a/components/polylith/info/collect.py
+++ b/components/polylith/info/collect.py
@@ -1,3 +1,4 @@
+import difflib
 from pathlib import Path
 from typing import List, Set
 
@@ -62,3 +63,11 @@ def find_unused_bases(root: Path, ns: str) -> Set[str]:
     bases_in_projects = set().union(*[p["bases"] for p in projects_data])
 
     return set(bases).difference(bases_in_projects)
+
+
+def sort_bases_by_closest_match(bases: Set[str], name: str) -> List[str]:
+    closest = difflib.get_close_matches(name, bases, cutoff=0.3)
+
+    rest = sorted([b for b in bases if b not in closest])
+
+    return closest + rest

--- a/components/polylith/poetry/commands/create_project.py
+++ b/components/polylith/poetry/commands/create_project.py
@@ -37,4 +37,6 @@ class CreateProjectCommand(Command):
 
         create(name, description, create_project)
 
+        project.interactive.run(name)
+
         return 0

--- a/components/polylith/project/__init__.py
+++ b/components/polylith/project/__init__.py
@@ -1,4 +1,4 @@
-from polylith.project import templates
+from polylith.project import interactive, templates
 from polylith.project.create import create_project
 from polylith.project.get import (
     get_packages_for_projects,
@@ -14,6 +14,7 @@ __all__ = [
     "get_project_name",
     "get_project_template",
     "get_toml",
+    "interactive",
     "parse_package_paths",
     "templates",
 ]

--- a/components/polylith/project/interactive.py
+++ b/components/polylith/project/interactive.py
@@ -12,12 +12,12 @@ console = Console(theme=theme.poly_theme)
 
 def create_added_brick_message(bricks: Set[str], tag: str, project_name: str) -> str:
     number_of_bricks = len(bricks)
-    plural = number_of_bricks > 1
+    plural = "s" if number_of_bricks > 1 else ""
 
     if tag == "base":
-        grammar = "bases" if plural else "base"
+        grammar = f"base{plural}"
     else:
-        grammar = "components" if plural else "component"
+        grammar = f"component{plural}"
 
     return f"[data]Added {number_of_bricks} [{tag}]{grammar}[/] to the [proj]{project_name}[/] project.[/]"
 

--- a/components/polylith/project/interactive.py
+++ b/components/polylith/project/interactive.py
@@ -56,6 +56,9 @@ def add_bricks_to_project(
     if not project_data:
         return
 
+    message = f"[data]Project [proj]{project_name}[/] created.[/]"
+    console.print(Padding(message, (0, 0, 1, 0)))
+
     first, *_ = possible_bases
 
     if not Confirm.ask(
@@ -96,8 +99,5 @@ def run(project_name: str) -> None:
 
     if not possible_bases:
         return
-
-    message = f"[data]Project [proj]{project_name}[/] created.[/]"
-    console.print(Padding(message, (0, 0, 1, 0)))
 
     add_bricks_to_project(root, ns, project_name, possible_bases)

--- a/components/polylith/project/interactive.py
+++ b/components/polylith/project/interactive.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+from typing import List, Set
+
+from polylith import configuration, info, repo, sync
+from polylith.reporting import theme
+from rich.console import Console
+from rich.padding import Padding
+from rich.prompt import Confirm, Prompt
+
+console = Console(theme=theme.poly_theme)
+
+
+def create_added_brick_message(bricks: Set[str], tag: str, project_name: str) -> str:
+    number_of_bricks = len(bricks)
+    plural = number_of_bricks > 1
+
+    if tag == "base":
+        grammar = "bases" if plural else "base"
+    else:
+        grammar = "components" if plural else "component"
+
+    return f"[data]Added {number_of_bricks} [{tag}]{grammar}[/] to the [proj]{project_name}[/] project.[/]"
+
+
+def confirmation(diff: dict, project_name: str) -> None:
+    pad = (1, 0, 0, 0)
+
+    if not diff:
+        nothing_added_message = f"[data]No bricks added to [proj]{project_name}[/][/]."
+        console.print(Padding(nothing_added_message, pad))
+
+        return
+
+    bases = diff["bases"]
+    components = diff["components"]
+
+    bases_message = create_added_brick_message(bases, "base", project_name)
+    console.print(Padding(bases_message, pad))
+
+    if len(components) == 0:
+        return
+
+    components_message = create_added_brick_message(components, "comp", project_name)
+    console.print(components_message)
+
+
+def add_bricks_to_project(
+    root: Path,
+    ns: str,
+    project_name: str,
+    possible_bases: List[str],
+) -> None:
+    projects_data = info.get_projects_data(root, ns)
+    project_data = next((p for p in projects_data if p["name"] == project_name), None)
+
+    if not project_data:
+        return
+
+    first, *_ = possible_bases
+
+    if not Confirm.ask(
+        prompt=f"[data]Do you want to add bricks to the [proj]{project_name}[/] project?[/]",
+        console=console,
+    ):
+        return
+
+    question = "[data]What's the name of the Polylith [base]base[/] to add?[/]"
+
+    base = Prompt.ask(
+        prompt=question,
+        console=console,
+        default=first,
+        show_default=True,
+        case_sensitive=False,
+    )
+
+    all_bases = info.get_bases(root, ns)
+    found_base = next((b for b in all_bases if str.lower(b) == str.lower(base)), None)
+
+    if not found_base:
+        confirmation({}, project_name)
+        return
+
+    diff = sync.calculate_needed_bricks(root, ns, project_data, found_base)
+
+    sync.update_project(root, ns, diff)
+
+    confirmation(diff, project_name)
+
+
+def run(project_name: str) -> None:
+    root = repo.get_workspace_root(Path.cwd())
+    ns = configuration.get_namespace_from_config(root)
+
+    possible_bases = sorted(info.find_unused_bases(root, ns))
+
+    if not possible_bases:
+        return
+
+    message = f"[data]Project [proj]{project_name}[/] created.[/]"
+    console.print(Padding(message, (0, 0, 1, 0)))
+
+    add_bricks_to_project(root, ns, project_name, possible_bases)

--- a/components/polylith/sync/__init__.py
+++ b/components/polylith/sync/__init__.py
@@ -1,5 +1,5 @@
 from polylith.sync import report
-from polylith.sync.collect import calculate_diff
+from polylith.sync.collect import calculate_diff, calculate_needed_bricks
 from polylith.sync.update import update_project
 
-__all__ = ["report", "calculate_diff", "update_project"]
+__all__ = ["report", "calculate_diff", "calculate_needed_bricks", "update_project"]

--- a/components/polylith/sync/collect.py
+++ b/components/polylith/sync/collect.py
@@ -31,3 +31,22 @@ def calculate_diff(root: Path, namespace: str, project_data: dict) -> dict:
         "components": components_diff,
         "brick_imports": brick_imports,
     }
+
+
+def calculate_needed_bricks(root: Path, namespace: str, base: str) -> dict:
+    bases = {base}
+    components: Set[str] = set()
+
+    all_bases = info.get_bases(root, namespace)
+    all_components = info.get_components(root, namespace)
+
+    brick_imports = deps.get_brick_imports(root, namespace, bases, components)
+    brick_diff = check.collect.imports_diff(brick_imports, bases, components)
+
+    bases_diff = {b for b in brick_diff if b in all_bases}
+    components_diff = {b for b in brick_diff if b in all_components}
+
+    return {
+        "bases": bases_diff,
+        "components": components_diff,
+    }

--- a/components/polylith/sync/collect.py
+++ b/components/polylith/sync/collect.py
@@ -1,19 +1,15 @@
 from pathlib import Path
+from typing import Set
 
 from polylith import check, deps, info
 
 
-def calculate_diff(
-    root: Path,
-    namespace: str,
-    project_data: dict,
-    workspace_data: dict,
-) -> dict:
+def calculate_diff(root: Path, namespace: str, project_data: dict) -> dict:
     bases = set(project_data["bases"])
     components = set(project_data["components"])
 
-    all_bases = workspace_data["bases"]
-    all_components = workspace_data["components"]
+    all_bases = info.get_bases(root, namespace)
+    all_components = info.get_components(root, namespace)
 
     brick_imports = deps.get_brick_imports(root, namespace, bases, components)
     is_project = info.is_project(project_data)

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.39.0"
+version = "1.40.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.32.0"
+version = "1.33.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding the possibility to interactively add base(s) and components to a newly created project.

`poly create project` will create the project data as before. If there are any unused bases in the Polylith workspace, the user will be asked to add a base to the project. Any other needed bricks (basically a `sync` operation) will be added to the newly created project.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is an idea coming from Discussion #352 ⭐ 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Manually running the `poly create project` command

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
