### PR TITLE
Remove pypistats until the api is online again

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ The main use case is to support having one or more microservices (or apps) in a 
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DavidVujic_python-polylith&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DavidVujic_python-polylith)
 
-Polith CLI total downloads: 298K (according to clickhouse and pepy.tech, August 12th 2025)
 
-Poetry Plugin total downloads: 820K (according to clickhouse and pepy.tech, August 12th 2025)
+:chart_with_upwards_trend: Polith CLI downloads: 298K
+:chart_with_upwards_trend: Poetry Plugin downloads: 820K
 
+(source: clickhouse and pepy.tech, from August 12th 2025)
 
 ## What's Polylith? :thinking:
 >... Polylith is a software architecture that applies functional thinking at the system scale. It helps us build simple, maintainable, testable, and scalable backend systems. ...

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ The main use case is to support having one or more microservices (or apps) in a 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DavidVujic_python-polylith&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DavidVujic_python-polylith)
 
 
-- :chart_with_upwards_trend: Polith CLI downloads: 298K
-- :chart_with_upwards_trend: Poetry Plugin downloads: 820K
+:chart_with_upwards_trend: Polith CLI downloads: 298K
+
+:chart_with_upwards_trend: Poetry Plugin downloads: 820K
+
 (source: clickhouse and pepy.tech, from August 12th 2025)
 
 ## What's Polylith? :thinking:

--- a/README.md
+++ b/README.md
@@ -10,12 +10,9 @@ The main use case is to support having one or more microservices (or apps) in a 
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DavidVujic_python-polylith&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DavidVujic_python-polylith)
 
+:chart_with_upwards_trend: Downloads: Polylith CLI 298K, Poetry Plugin 820K
 
-:chart_with_upwards_trend: Polith CLI downloads: 298K
-
-:chart_with_upwards_trend: Poetry Plugin downloads: 820K
-
-(source: clickhouse and pepy.tech, from August 12th 2025)
+(downloads source: clickhouse and pepy.tech, from August 12th 2025)
 
 ## What's Polylith? :thinking:
 >... Polylith is a software architecture that applies functional thinking at the system scale. It helps us build simple, maintainable, testable, and scalable backend systems. ...

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ The main use case is to support having one or more microservices (or apps) in a 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DavidVujic_python-polylith&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DavidVujic_python-polylith)
 
 
-:chart_with_upwards_trend: Polith CLI downloads: 298K
-:chart_with_upwards_trend: Poetry Plugin downloads: 820K
-
+- :chart_with_upwards_trend: Polith CLI downloads: 298K
+- :chart_with_upwards_trend: Poetry Plugin downloads: 820K
 (source: clickhouse and pepy.tech, from August 12th 2025)
 
 ## What's Polylith? :thinking:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The main use case is to support having one or more microservices (or apps) in a 
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DavidVujic_python-polylith&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DavidVujic_python-polylith)
 
-[![Download Stats](https://img.shields.io/pypi/dm/poetry-polylith-plugin?label=Poetry%20plugin%20Downloads)](https://pypistats.org/packages/poetry-polylith-plugin)
+Polith CLI total downloads: 298K (according to clickhouse and pepy.tech, August 12th 2025)
 
-[![Download Stats](https://img.shields.io/pypi/dm/polylith-cli?label=CLI%20Downloads)](https://pypistats.org/packages/polylith-cli)
+Poetry Plugin total downloads: 820K (according to clickhouse and pepy.tech, August 12th 2025)
 
 
 ## What's Polylith? :thinking:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removing the download badges from pypistats (hopefully temporary).

Replacing with static stats, originating from Clickhouse and pepy.tech.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Pypistats service seems to be unmaintained, and has been offline for more than one week. In case the service will be online again, the changes of this Pull Request will be reverted.

More content in this pypistats issue:
https://github.com/crflynn/pypistats.org/issues/82