### PR TITLE
feat(poly deps, info, libs): save contents to file command option

### DIFF
--- a/bases/polylith/cli/core.py
+++ b/bases/polylith/cli/core.py
@@ -59,9 +59,20 @@ def enriched_with_lock_files_data(
 
 
 @app.command("info")
-def info_command(short: Annotated[bool, options.short_workspace] = False):
+def info_command(
+    short: Annotated[bool, options.short_workspace] = False,
+    save: Annotated[bool, options.save] = False,
+):
     """Info about the Polylith workspace."""
-    commands.info.run(short)
+    root = repo.get_workspace_root(Path.cwd())
+    output = configuration.get_output_dir(root, "info") if save else None
+
+    cli_options = {
+        "short": short,
+        "save": save,
+        "output": output,
+    }
+    commands.info.run(root, cli_options)
 
 
 @app.command("check")

--- a/bases/polylith/cli/core.py
+++ b/bases/polylith/cli/core.py
@@ -160,7 +160,6 @@ def libs_command(
 
 @app.command("sync")
 def sync_command(
-    strict: Annotated[bool, options.strict] = False,
     quiet: Annotated[bool, options.quiet] = False,
     directory: Annotated[str, options.directory] = "",
     verbose: Annotated[bool, options.verbose] = False,
@@ -172,7 +171,6 @@ def sync_command(
     all_projects_data = info.get_projects_data(root, ns)
 
     cli_options = {
-        "strict": strict,
         "quiet": quiet,
         "verbose": verbose,
     }

--- a/bases/polylith/cli/core.py
+++ b/bases/polylith/cli/core.py
@@ -131,17 +131,21 @@ def libs_command(
     directory: Annotated[str, options.directory] = "",
     alias: Annotated[str, options.alias] = "",
     short: Annotated[bool, options.short] = False,
+    save: Annotated[bool, options.save] = False,
 ):
     """Show third-party libraries used in the workspace."""
     root = repo.get_workspace_root(Path.cwd())
     ns = configuration.get_namespace_from_config(root)
 
     all_projects_data = info.get_projects_data(root, ns)
+    output = configuration.get_output_dir(root, "deps") if save else None
 
     cli_options = {
         "strict": strict,
         "alias": str.split(alias, ",") if alias else [],
         "short": short,
+        "save": save,
+        "output": output,
     }
 
     projects_data = filtered_projects_data(all_projects_data, directory)

--- a/bases/polylith/cli/core.py
+++ b/bases/polylith/cli/core.py
@@ -179,8 +179,14 @@ def deps_command(
     ns = configuration.get_namespace_from_config(root)
 
     dir_path = Path(directory).as_posix() if directory else None
+    output = configuration.get_output_dir(root, "deps") if save else None
 
-    cli_options = {"directory": dir_path, "brick": brick or None, "save": save}
+    cli_options = {
+        "directory": dir_path,
+        "brick": brick or None,
+        "save": save,
+        "output": output,
+    }
 
     commands.deps.run(root, ns, cli_options)
 

--- a/bases/polylith/cli/core.py
+++ b/bases/polylith/cli/core.py
@@ -138,7 +138,7 @@ def libs_command(
     ns = configuration.get_namespace_from_config(root)
 
     all_projects_data = info.get_projects_data(root, ns)
-    output = configuration.get_output_dir(root, "deps") if save else None
+    output = configuration.get_output_dir(root, "libs") if save else None
 
     cli_options = {
         "strict": strict,

--- a/bases/polylith/cli/core.py
+++ b/bases/polylith/cli/core.py
@@ -172,6 +172,7 @@ def sync_command(
 def deps_command(
     directory: Annotated[str, options.directory] = "",
     brick: Annotated[str, options.brick] = "",
+    save: Annotated[bool, options.save] = False,
 ):
     """Visualize the dependencies between bricks."""
     root = repo.get_workspace_root(Path.cwd())
@@ -179,7 +180,9 @@ def deps_command(
 
     dir_path = Path(directory).as_posix() if directory else None
 
-    commands.deps.run(root, ns, dir_path, brick or None)
+    cli_options = {"directory": dir_path, "brick": brick or None, "save": save}
+
+    commands.deps.run(root, ns, cli_options)
 
 
 if __name__ == "__main__":

--- a/bases/polylith/cli/options.py
+++ b/bases/polylith/cli/options.py
@@ -18,5 +18,4 @@ verbose = Option(help="More verbose output.")
 quiet = Option(help="Do not output any messages.")
 
 brick = Option(help="Shows dependencies for selected brick.")
-
 save = Option(help="Store the contents of this command to file.")

--- a/bases/polylith/cli/options.py
+++ b/bases/polylith/cli/options.py
@@ -18,3 +18,5 @@ verbose = Option(help="More verbose output.")
 quiet = Option(help="Do not output any messages.")
 
 brick = Option(help="Shows dependencies for selected brick.")
+
+save = Option(help="Store the contents of this command to file.")

--- a/components/polylith/commands/deps.py
+++ b/components/polylith/commands/deps.py
@@ -4,7 +4,9 @@ from typing import List, Set
 from polylith import bricks, deps, info
 
 
-def get_imports(root: Path, ns: str, bases: Set[str], components: Set[str]) -> dict:
+def get_imports(root: Path, ns: str, bricks: dict) -> dict:
+    bases = bricks["bases"]
+    components = bricks["components"]
     brick_imports = deps.get_brick_imports(root, ns, bases, components)
 
     return {**brick_imports["bases"], **brick_imports["components"]}
@@ -35,13 +37,15 @@ def run(root: Path, ns: str, options: dict):
     projects_data = info.get_projects_data(root, ns) if directory else []
     project = next((p for p in projects_data if directory in p["path"].as_posix()), {})
 
-    bases = get_bases(root, ns, project)
-    components = get_components(root, ns, project)
+    bricks = {
+        "bases": get_bases(root, ns, project),
+        "components": get_components(root, ns, project),
+    }
 
-    imports = get_imports(root, ns, bases, components)
+    imports = get_imports(root, ns, bricks)
 
     if brick and imports.get(brick):
-        deps.print_brick_deps(brick, bases, components, imports)
+        deps.print_brick_deps(brick, bricks, imports, options)
         return
 
-    deps.print_deps(bases, components, imports, options)
+    deps.print_deps(bricks, imports, options)

--- a/components/polylith/commands/deps.py
+++ b/components/polylith/commands/deps.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Set, Union
+from typing import List, Set
 
 from polylith import bricks, deps, info
 
@@ -28,7 +28,10 @@ def get_components(root: Path, ns: str, project_data: dict) -> Set[str]:
     return pick_name(bricks.get_components_data(root, ns))
 
 
-def run(root: Path, ns: str, directory: Union[str, None], brick: Union[str, None]):
+def run(root: Path, ns: str, options: dict):
+    directory = options.get("directory")
+    brick = options.get("brick")
+
     projects_data = info.get_projects_data(root, ns) if directory else []
     project = next((p for p in projects_data if directory in p["path"].as_posix()), {})
 
@@ -41,4 +44,4 @@ def run(root: Path, ns: str, directory: Union[str, None], brick: Union[str, None
         deps.print_brick_deps(brick, bases, components, imports)
         return
 
-    deps.print_deps(bases, components, imports)
+    deps.print_deps(bases, components, imports, options)

--- a/components/polylith/commands/info.py
+++ b/components/polylith/commands/info.py
@@ -9,7 +9,7 @@ def run(root: Path, options: dict):
     components = info.get_components(root, ns)
     projects_data = info.get_bricks_in_projects(root, components, bases, ns)
 
-    info.print_workspace_summary(projects_data, bases, components)
+    info.print_workspace_summary(projects_data, bases, components, options)
 
     if not components and not bases:
         return

--- a/components/polylith/commands/info.py
+++ b/components/polylith/commands/info.py
@@ -1,11 +1,9 @@
 from pathlib import Path
 
-from polylith import configuration, info, repo
+from polylith import configuration, info
 
 
-def run(short: bool):
-    root = repo.get_workspace_root(Path.cwd())
-
+def run(root: Path, options: dict):
     ns = configuration.get_namespace_from_config(root)
     bases = info.get_bases(root, ns)
     components = info.get_components(root, ns)
@@ -16,9 +14,4 @@ def run(short: bool):
     if not components and not bases:
         return
 
-    if short:
-        info.print_compressed_view_for_bricks_in_projects(
-            projects_data, bases, components
-        )
-    else:
-        info.print_bricks_in_projects(projects_data, bases, components)
+    info.print_bricks_in_projects(projects_data, bases, components, options)

--- a/components/polylith/commands/libs.py
+++ b/components/polylith/commands/libs.py
@@ -61,6 +61,6 @@ def run(
     flattened: dict = reduce(flatten_imports, imports.values(), {})
 
     report.print_libs_summary()
-    report.print_libs_in_bricks(flattened)
+    report.print_libs_in_bricks(flattened, options)
 
     return {missing_libs(p, imports, options) for p in projects_data}

--- a/components/polylith/configuration/__init__.py
+++ b/components/polylith/configuration/__init__.py
@@ -1,6 +1,7 @@
 from polylith.configuration.core import (
     get_brick_structure_from_config,
     get_namespace_from_config,
+    get_output_dir,
     get_resources_structure_from_config,
     get_tag_pattern_from_config,
     get_tag_sort_options_from_config,
@@ -13,6 +14,7 @@ from polylith.configuration.core import (
 __all__ = [
     "get_brick_structure_from_config",
     "get_namespace_from_config",
+    "get_output_dir",
     "get_resources_structure_from_config",
     "get_tag_pattern_from_config",
     "get_tag_sort_options_from_config",

--- a/components/polylith/configuration/core.py
+++ b/components/polylith/configuration/core.py
@@ -81,3 +81,18 @@ def get_resources_structure_from_config(path: Path) -> str:
         return "{brick}/{namespace}/{package}"
 
     return "{brick}/{package}"
+
+
+def get_output_dir(path: Path, command_name: str) -> str:
+    toml: dict = repo.load_workspace_config(path)
+
+    key = "output"
+
+    tool = toml["tool"]["polylith"]
+    commands = tool.get("commands", {})
+    command = commands.get(command_name, {})
+
+    output = command.get(key) or commands.get(key)
+    fallback = f"{repo.development_dir}/poly"
+
+    return output or fallback

--- a/components/polylith/deps/report.py
+++ b/components/polylith/deps/report.py
@@ -1,6 +1,6 @@
 from functools import reduce
 from itertools import zip_longest
-from typing import List, Set, Tuple
+from typing import List, Set, Tuple, Union
 
 from polylith import output
 from polylith.reporting import theme
@@ -58,6 +58,20 @@ def create_rows(
     return comp_rows + base_rows
 
 
+def find_longest_brick_name(bases: Set[str], components: Set[str]) -> str:
+    bricks = set().union(bases, components)
+
+    return max(bricks, key=len)
+
+
+def calculate_brick_column_width(
+    bases: Set[str], components: Set[str]
+) -> Union[int, None]:
+    longest = find_longest_brick_name(bases, components)
+
+    return len(longest)
+
+
 def print_deps(bricks: dict, import_data: dict, options: dict):
     bases = bricks["bases"]
     components = bricks["components"]
@@ -66,9 +80,11 @@ def print_deps(bricks: dict, import_data: dict, options: dict):
     imported_bases = sorted({b for b in flattened if b in bases})
     imported_components = sorted({c for c in flattened if c in components})
     imported_bricks = imported_components + imported_bases
+    save = options.get("save", False)
 
     table = Table(box=box.SIMPLE_HEAD)
-    table.add_column("[data]brick[/]")
+    brick_width = calculate_brick_column_width(bases, components)
+    table.add_column("[data]brick[/]", width=brick_width)
 
     cols = create_columns(imported_bases, imported_components)
     rows = create_rows(bases, components, import_data, imported_bricks)
@@ -79,13 +95,11 @@ def print_deps(bricks: dict, import_data: dict, options: dict):
     for row in rows:
         table.add_row(*row)
 
-    save = options.get("save", False)
-
-    console = Console(theme=theme.poly_theme, record=save)
+    console = Console(theme=theme.poly_theme)
     console.print(table, overflow="ellipsis")
 
     if save:
-        output.save(console, options, "deps")
+        output.save(table, options, "deps")
 
 
 def without(key: str, bricks: Set[str]) -> Set[str]:
@@ -130,7 +144,7 @@ def print_brick_deps(brick: str, bricks: dict, import_data: dict, options: dict)
 
     tag = calculate_tag(brick, bases)
 
-    console = Console(theme=theme.poly_theme, record=save)
+    console = Console(theme=theme.poly_theme)
 
     table = Table(box=box.SIMPLE_HEAD)
     table.add_column("[data]used by[/]")
@@ -155,4 +169,4 @@ def print_brick_deps(brick: str, bricks: dict, import_data: dict, options: dict)
     console.print(table, overflow="ellipsis")
 
     if save:
-        output.save(console, options, f"deps_{brick}")
+        output.save(table, options, f"deps_{brick}")

--- a/components/polylith/deps/report.py
+++ b/components/polylith/deps/report.py
@@ -1,8 +1,8 @@
 from functools import reduce
 from itertools import zip_longest
-from pathlib import Path
 from typing import List, Set, Tuple
 
+from polylith import output
 from polylith.reporting import theme
 from rich import box
 from rich.console import Console
@@ -58,19 +58,6 @@ def create_rows(
     return comp_rows + base_rows
 
 
-def save_output(console: Console, options: dict, command: str) -> None:
-    exported = console.export_text()
-    replacements = {"\u2714": "X", "\U0001F448": "<", "\U0001F449": ">"}
-
-    adjusted = reduce(lambda acc, kv: str.replace(acc, *kv), replacements.items(), exported)
-
-    output = options["output"]
-    fullpath = f"{output}/{command}.txt"
-
-    Path(output).mkdir(parents=True, exist_ok=True)
-    Path(fullpath).write_text(adjusted)
-
-
 def print_deps(bricks: dict, import_data: dict, options: dict):
     bases = bricks["bases"]
     components = bricks["components"]
@@ -98,7 +85,7 @@ def print_deps(bricks: dict, import_data: dict, options: dict):
     console.print(table, overflow="ellipsis")
 
     if save:
-        save_output(console, options, "deps")
+        output.save(console, options, "deps")
 
 
 def without(key: str, bricks: Set[str]) -> Set[str]:
@@ -168,4 +155,4 @@ def print_brick_deps(brick: str, bricks: dict, import_data: dict, options: dict)
     console.print(table, overflow="ellipsis")
 
     if save:
-        save_output(console, options, f"deps_{brick}")
+        output.save(console, options, f"deps_{brick}")

--- a/components/polylith/deps/report.py
+++ b/components/polylith/deps/report.py
@@ -60,7 +60,7 @@ def create_rows(
 
 def save_output(console: Console, options: dict, command: str) -> None:
     exported = console.export_text()
-    replacements = {"\u2714": "X", "\U0001F448": "<-", "\U0001F449": "->"}
+    replacements = {"\u2714": "X", "\U0001F448": "<", "\U0001F449": ">"}
 
     adjusted = reduce(lambda acc, kv: str.replace(acc, *kv), replacements.items(), exported)
 

--- a/components/polylith/deps/report.py
+++ b/components/polylith/deps/report.py
@@ -3,7 +3,6 @@ from itertools import zip_longest
 from pathlib import Path
 from typing import List, Set, Tuple
 
-from polylith import repo
 from polylith.reporting import theme
 from rich import box
 from rich.console import Console
@@ -59,14 +58,14 @@ def create_rows(
     return comp_rows + base_rows
 
 
-def save_deps_output(console: Console) -> None:
+def save_deps_output(console: Console, options: dict) -> None:
     exported = console.export_text()
+    adjusted = exported.replace("\u2714", "X")
 
-    adjusted_output = exported.replace("\u2714", "X")
+    output = options["output"]
+    fullpath = f"{output}/deps.txt"
 
-    fullpath = f"{repo.report_dir}/deps.txt"
-
-    Path(fullpath).write_text(adjusted_output)
+    Path(fullpath).write_text(adjusted)
 
 
 def print_deps(bases: Set[str], components: Set[str], import_data: dict, options: dict):
@@ -94,7 +93,7 @@ def print_deps(bases: Set[str], components: Set[str], import_data: dict, options
     console.print(table, overflow="ellipsis")
 
     if save:
-        save_deps_output(console)
+        save_deps_output(console, options)
 
 
 def without(key: str, bricks: Set[str]) -> Set[str]:

--- a/components/polylith/info/__init__.py
+++ b/components/polylith/info/__init__.py
@@ -8,7 +8,6 @@ from polylith.info.collect import (
 from polylith.info.report import (
     is_project,
     print_bricks_in_projects,
-    print_compressed_view_for_bricks_in_projects,
     print_workspace_summary,
 )
 
@@ -20,6 +19,5 @@ __all__ = [
     "get_projects_data",
     "is_project",
     "print_bricks_in_projects",
-    "print_compressed_view_for_bricks_in_projects",
     "print_workspace_summary",
 ]

--- a/components/polylith/info/report.py
+++ b/components/polylith/info/report.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from polylith import output
 from polylith.reporting import theme
 from rich import box
 from rich.console import Console
@@ -67,28 +68,21 @@ def build_bricks_in_projects_table(
     return table
 
 
-def print_table(table: Table) -> None:
-    console = Console(theme=theme.poly_theme)
+def print_bricks_in_projects(
+    projects_data: List[dict],
+    bases: List[str],
+    components: List[str],
+    options: dict,
+) -> None:
+    table = build_bricks_in_projects_table(projects_data, bases, components, options)
+
+    save = options.get("save", False)
+    console = Console(theme=theme.poly_theme, record=save)
 
     console.print(table, overflow="ellipsis")
 
-
-def print_compressed_view_for_bricks_in_projects(
-    projects_data: List[dict], bases: List[str], components: List[str]
-) -> None:
-    options = {"short": True}
-    table = build_bricks_in_projects_table(projects_data, bases, components, options)
-
-    print_table(table)
-
-
-def print_bricks_in_projects(
-    projects_data: List[dict], bases: List[str], components: List[str]
-) -> None:
-    options = {"short": False}
-    table = build_bricks_in_projects_table(projects_data, bases, components, options)
-
-    print_table(table)
+    if save:
+        output.save(console, options, "info")
 
 
 def print_workspace_summary(

--- a/components/polylith/info/report.py
+++ b/components/polylith/info/report.py
@@ -86,9 +86,13 @@ def print_bricks_in_projects(
 
 
 def print_workspace_summary(
-    projects_data: List[dict], bases: List[str], components: List[str]
+    projects_data: List[dict],
+    bases: List[str],
+    components: List[str],
+    options: dict,
 ) -> None:
-    console = Console(theme=theme.poly_theme)
+    save = options.get("save", False)
+    console = Console(theme=theme.poly_theme, record=save)
 
     console.print(Padding("[data]Workspace summary[/]", (1, 0, 1, 0)))
 
@@ -101,3 +105,6 @@ def print_workspace_summary(
     console.print(f"[comp]components[/]: [data]{number_of_components}[/]")
     console.print(f"[base]bases[/]: [data]{number_of_bases}[/]")
     console.print(f"[data]development[/]: [data]{number_of_dev}[/]")
+
+    if save:
+        output.save(console, options, "workspace_summary")

--- a/components/polylith/info/report.py
+++ b/components/polylith/info/report.py
@@ -77,12 +77,12 @@ def print_bricks_in_projects(
     table = build_bricks_in_projects_table(projects_data, bases, components, options)
 
     save = options.get("save", False)
-    console = Console(theme=theme.poly_theme, record=save)
+    console = Console(theme=theme.poly_theme)
 
     console.print(table, overflow="ellipsis")
 
     if save:
-        output.save(console, options, "info")
+        output.save(table, options, "info")
 
 
 def print_workspace_summary(
@@ -107,4 +107,4 @@ def print_workspace_summary(
     console.print(f"[data]development[/]: [data]{number_of_dev}[/]")
 
     if save:
-        output.save(console, options, "workspace_summary")
+        output.save_recorded(console, options, "workspace_summary")

--- a/components/polylith/libs/report.py
+++ b/components/polylith/libs/report.py
@@ -3,7 +3,7 @@ from operator import itemgetter
 from pathlib import Path
 from typing import List, Set, Union
 
-from polylith import workspace
+from polylith import output, workspace
 from polylith.libs import grouping
 from polylith.reporting import theme
 from rich import box, markup
@@ -69,7 +69,7 @@ def print_libs_summary() -> None:
     console.print(Padding("[data]Libraries in bricks[/]", (1, 0, 0, 0)))
 
 
-def print_libs_in_bricks(brick_imports: dict) -> None:
+def print_libs_in_bricks(brick_imports: dict, options: dict) -> None:
     bases_imports = flatten_imports(brick_imports, "bases")
     components_imports = flatten_imports(brick_imports, "components")
 
@@ -92,6 +92,11 @@ def print_libs_in_bricks(brick_imports: dict) -> None:
         table.add_row(f"[base]{brick}[/]", ", ".join(sorted(imports)))
 
     console.print(table, overflow="ellipsis")
+
+    save = options.get("save", False)
+
+    if save:
+        output.save(table, options, "libs")
 
 
 def print_missing_installed_libs(
@@ -191,12 +196,17 @@ def print_libs_in_projects(
     if not flattened:
         return
 
+    save = options.get("save", False)
+
     table = libs_in_projects_table(development_data, projects_data, flattened, options)
 
     console = Console(theme=theme.poly_theme)
 
     console.print(Padding("[data]Library versions in projects[/]", (1, 0, 0, 0)))
     console.print(table, overflow="ellipsis")
+
+    if save:
+        output.save(table, options, "libs_in_projects")
 
 
 def has_different_version(

--- a/components/polylith/output/__init__.py
+++ b/components/polylith/output/__init__.py
@@ -1,3 +1,3 @@
-from polylith.output.core import save
+from polylith.output.core import save, save_recorded
 
-__all__ = ["save"]
+__all__ = ["save", "save_recorded"]

--- a/components/polylith/output/__init__.py
+++ b/components/polylith/output/__init__.py
@@ -1,0 +1,3 @@
+from polylith.output.core import save
+
+__all__ = ["save"]

--- a/components/polylith/output/core.py
+++ b/components/polylith/output/core.py
@@ -1,0 +1,26 @@
+from functools import reduce
+from pathlib import Path
+from typing import Tuple
+
+from rich.console import Console
+
+replacements = {"\u2714": "X", "\U0001F448": "<", "\U0001F449": ">"}
+
+
+def replace_char(data: str, pair: Tuple[str, str]) -> str:
+    return str.replace(data, *pair)
+
+
+def adjust(data: str) -> str:
+    return reduce(replace_char, replacements.items(), data)
+
+
+def save(console: Console, options: dict, command: str) -> None:
+    exported = console.export_text()
+    adjusted = adjust(exported)
+
+    output = options["output"]
+    fullpath = f"{output}/{command}.txt"
+
+    Path(output).mkdir(parents=True, exist_ok=True)
+    Path(fullpath).write_text(adjusted)

--- a/components/polylith/output/core.py
+++ b/components/polylith/output/core.py
@@ -1,10 +1,13 @@
 from functools import reduce
+from io import StringIO
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, cast
 
+from polylith.reporting import theme
 from rich.console import Console
+from rich.table import Table
 
-replacements = {"\u2714": "X", "\U0001F448": "<", "\U0001F449": ">"}
+replacements = {"\u2714": "X", "\U0001F448": "<-", "\U0001F449": "->"}
 
 
 def replace_char(data: str, pair: Tuple[str, str]) -> str:
@@ -15,12 +18,28 @@ def adjust(data: str) -> str:
     return reduce(replace_char, replacements.items(), data)
 
 
-def save(console: Console, options: dict, command: str) -> None:
-    exported = console.export_text()
-    adjusted = adjust(exported)
+def write_to_file(data: str, options: dict, command: str) -> None:
+    adjusted = adjust(data)
 
     output = options["output"]
     fullpath = f"{output}/{command}.txt"
 
     Path(output).mkdir(parents=True, exist_ok=True)
     Path(fullpath).write_text(adjusted)
+
+
+def save_recorded(console: Console, options: dict, command: str) -> None:
+    exported = console.export_text()
+
+    write_to_file(exported, options, command)
+
+
+def save(table: Table, options: dict, command: str) -> None:
+    console = Console(theme=theme.poly_theme, width=1024, file=StringIO())
+
+    console.print(table, overflow="ellipsis")
+
+    f = cast(StringIO, console.file)
+    exported = f.getvalue()
+
+    write_to_file(exported, options, command)

--- a/components/polylith/poetry/commands/check.py
+++ b/components/polylith/poetry/commands/check.py
@@ -1,31 +1,17 @@
 from functools import partial
 from pathlib import Path
 
-from cleo.helpers import option
 from poetry.console.commands.command import Command
 from polylith import commands, configuration, info, repo
 from polylith.poetry import internals
-
-command_options = [
-    option(
-        long_name="strict",
-        description="More strict checks when matching name and version of third-party libraries and imports.",
-        flag=True,
-    ),
-    option(
-        long_name="alias",
-        description="alias for a third-party library, useful when an import differ from the library name",
-        flag=False,
-        multiple=True,
-    ),
-]
+from polylith.poetry.commands import command_options
 
 
 class CheckCommand(Command):
     name = "poly check"
     description = "Validates the <comment>Polylith</> workspace."
 
-    options = command_options
+    options = [command_options.alias, command_options.strict]
 
     def merged_project_data(self, project_data: dict) -> dict:
         name = project_data["name"]

--- a/components/polylith/poetry/commands/command_options.py
+++ b/components/polylith/poetry/commands/command_options.py
@@ -1,0 +1,35 @@
+from cleo.helpers import option
+
+alias = option(
+    long_name="alias",
+    description="alias for a third-party library, useful when an import differ from the library name",
+    flag=False,
+    multiple=True,
+)
+
+
+save = option(
+    long_name="save",
+    description="Store the contents of this command to file",
+    flag=True,
+)
+
+
+short = option(
+    long_name="short",
+    short_name="s",
+    description="Print short view",
+    flag=True,
+)
+
+since = option(
+    long_name="since",
+    description="Changed since a specific tag",
+    flag=False,
+)
+
+strict = option(
+    long_name="strict",
+    description="More strict checks when matching name and version of third-party libraries and imports.",
+    flag=True,
+)

--- a/components/polylith/poetry/commands/deps.py
+++ b/components/polylith/poetry/commands/deps.py
@@ -15,17 +15,24 @@ class DepsCommand(Command):
             description="Shows dependencies for selected brick",
             flag=False,
         ),
+        option(
+            long_name="save",
+            description="Store the contents of this command to file",
+            flag=True,
+        ),
     ]
 
     def handle(self) -> int:
         directory = self.option("directory")
         brick = self.option("brick")
+        save = self.option("save")
 
         root = repo.get_workspace_root(Path.cwd())
         ns = configuration.get_namespace_from_config(root)
 
         dir_path = Path(directory).as_posix() if directory else None
 
-        commands.deps.run(root, ns, dir_path, brick)
+        options = {"directory": dir_path, "brick": brick, "save": save}
+        commands.deps.run(root, ns, options)
 
         return 0

--- a/components/polylith/poetry/commands/deps.py
+++ b/components/polylith/poetry/commands/deps.py
@@ -1,6 +1,6 @@
 from pathlib import Path
-from cleo.helpers import option
 
+from cleo.helpers import option
 from poetry.console.commands.command import Command
 from polylith import commands, configuration, repo
 

--- a/components/polylith/poetry/commands/deps.py
+++ b/components/polylith/poetry/commands/deps.py
@@ -31,8 +31,14 @@ class DepsCommand(Command):
         ns = configuration.get_namespace_from_config(root)
 
         dir_path = Path(directory).as_posix() if directory else None
+        output = configuration.get_output_dir(root, "deps") if save else None
 
-        options = {"directory": dir_path, "brick": brick, "save": save}
+        options = {
+            "directory": dir_path,
+            "brick": brick,
+            "save": save,
+            "output": output,
+        }
         commands.deps.run(root, ns, options)
 
         return 0

--- a/components/polylith/poetry/commands/deps.py
+++ b/components/polylith/poetry/commands/deps.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from cleo.helpers import option
 from poetry.console.commands.command import Command
 from polylith import commands, configuration, repo
+from polylith.poetry.commands import command_options
 
 
 class DepsCommand(Command):
@@ -15,11 +16,7 @@ class DepsCommand(Command):
             description="Shows dependencies for selected brick",
             flag=False,
         ),
-        option(
-            long_name="save",
-            description="Store the contents of this command to file",
-            flag=True,
-        ),
+        command_options.save,
     ]
 
     def handle(self) -> int:

--- a/components/polylith/poetry/commands/diff.py
+++ b/components/polylith/poetry/commands/diff.py
@@ -1,27 +1,16 @@
 from cleo.helpers import option
 from poetry.console.commands.command import Command
 from polylith import commands
-
-command_options = [
-    option(
-        long_name="short",
-        short_name="s",
-        description="Print short view",
-        flag=True,
-    ),
-    option(
-        long_name="since",
-        description="Changed since a specific tag",
-        flag=False,
-    ),
-]
+from polylith.poetry.commands import command_options
 
 
 class DiffCommand(Command):
     name = "poly diff"
     description = "Shows changed bricks compared to the latest git tag."
 
-    options = command_options + [
+    options = [
+        command_options.short,
+        command_options.since,
         option(
             long_name="bricks",
             description="Print changed bricks",

--- a/components/polylith/poetry/commands/info.py
+++ b/components/polylith/poetry/commands/info.py
@@ -1,6 +1,8 @@
+from pathlib import Path
+
 from cleo.helpers import option
 from poetry.console.commands.command import Command
-from polylith import commands
+from polylith import commands, configuration, repo
 
 
 class InfoCommand(Command):
@@ -14,11 +16,25 @@ class InfoCommand(Command):
             description="Display Workspace Info adjusted for many projects",
             flag=True,
         ),
+        option(
+            long_name="save",
+            description="Store the contents of this command to file",
+            flag=True,
+        ),
     ]
 
     def handle(self) -> int:
         short = True if self.option("short") else False
+        save = self.option("save")
 
-        commands.info.run(short)
+        root = repo.get_workspace_root(Path.cwd())
+        output = configuration.get_output_dir(root, "info") if save else None
+
+        options = {
+            "short": short,
+            "save": save,
+            "output": output,
+        }
+        commands.info.run(root, options)
 
         return 0

--- a/components/polylith/poetry/commands/info.py
+++ b/components/polylith/poetry/commands/info.py
@@ -1,27 +1,15 @@
 from pathlib import Path
 
-from cleo.helpers import option
 from poetry.console.commands.command import Command
 from polylith import commands, configuration, repo
+from polylith.poetry.commands import command_options
 
 
 class InfoCommand(Command):
     name = "poly info"
     description = "Info about the <comment>Polylith</> workspace."
 
-    options = [
-        option(
-            long_name="short",
-            short_name="s",
-            description="Display Workspace Info adjusted for many projects",
-            flag=True,
-        ),
-        option(
-            long_name="save",
-            description="Store the contents of this command to file",
-            flag=True,
-        ),
-    ]
+    options = [command_options.save, command_options.short]
 
     def handle(self) -> int:
         short = True if self.option("short") else False

--- a/components/polylith/poetry/commands/libs.py
+++ b/components/polylith/poetry/commands/libs.py
@@ -39,6 +39,7 @@ class LibsCommand(Command):
             "strict": self.option("strict"),
             "alias": self.option("alias"),
             "short": self.option("short"),
+            "save": self.option("save"),
             "dists_fn": dists_fn,
         }
 

--- a/components/polylith/poetry/commands/libs.py
+++ b/components/polylith/poetry/commands/libs.py
@@ -1,10 +1,9 @@
 from functools import partial
 from pathlib import Path
 
-from cleo.helpers import option
 from poetry.console.commands.command import Command
 from polylith import commands, configuration, info, repo
-from polylith.poetry.commands.check import command_options
+from polylith.poetry.commands import command_options
 from polylith.poetry.internals import (
     distributions,
     filter_projects_data,
@@ -16,13 +15,11 @@ class LibsCommand(Command):
     name = "poly libs"
     description = "Show third-party libraries used in the workspace."
 
-    options = command_options + [
-        option(
-            long_name="short",
-            short_name="s",
-            description="Print short view",
-            flag=True,
-        ),
+    options = [
+        command_options.alias,
+        command_options.save,
+        command_options.short,
+        command_options.strict,
     ]
 
     def merged_project_data(self, project_data: dict) -> dict:

--- a/components/polylith/poetry/commands/libs.py
+++ b/components/polylith/poetry/commands/libs.py
@@ -34,12 +34,16 @@ class LibsCommand(Command):
     def handle(self) -> int:
         root = repo.get_workspace_root(Path.cwd())
         dists_fn = partial(distributions, root)
+        save = self.option("save")
+
+        output = configuration.get_output_dir(root, "libs") if save else None
 
         options = {
             "strict": self.option("strict"),
             "alias": self.option("alias"),
             "short": self.option("short"),
-            "save": self.option("save"),
+            "save": save,
+            "output": output,
             "dists_fn": dists_fn,
         }
 

--- a/components/polylith/poetry/commands/test.py
+++ b/components/polylith/poetry/commands/test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from cleo.helpers import option
 from poetry.console.commands.command import Command
 from polylith import commands, configuration, diff, repo
-from polylith.poetry.commands.diff import command_options
+from polylith.poetry.commands import command_options
 
 
 class TestDiffCommand(Command):
@@ -12,7 +12,9 @@ class TestDiffCommand(Command):
         "Shows the Polylith projects and bricks that are affected by changes in tests."
     )
 
-    options = command_options + [
+    options = [
+        command_options.short,
+        command_options.since,
         option(
             long_name="bricks",
             description="Bricks affected by changes in tests",

--- a/components/polylith/repo/__init__.py
+++ b/components/polylith/repo/__init__.py
@@ -12,7 +12,6 @@ from polylith.repo.repo import (
     load_workspace_config,
     projects_dir,
     readme_file,
-    report_dir,
     workspace_file,
 )
 
@@ -31,6 +30,5 @@ __all__ = [
     "load_workspace_config",
     "projects_dir",
     "readme_file",
-    "report_dir",
     "workspace_file",
 ]

--- a/components/polylith/repo/__init__.py
+++ b/components/polylith/repo/__init__.py
@@ -12,6 +12,7 @@ from polylith.repo.repo import (
     load_workspace_config,
     projects_dir,
     readme_file,
+    report_dir,
     workspace_file,
 )
 
@@ -30,5 +31,6 @@ __all__ = [
     "load_workspace_config",
     "projects_dir",
     "readme_file",
+    "report_dir",
     "workspace_file",
 ]

--- a/components/polylith/repo/repo.py
+++ b/components/polylith/repo/repo.py
@@ -13,6 +13,7 @@ bases_dir = "bases"
 components_dir = "components"
 projects_dir = "projects"
 development_dir = "development"
+report_dir = f"{development_dir}/poly"
 
 
 def load_content(fullpath: Path) -> tomlkit.TOMLDocument:

--- a/components/polylith/repo/repo.py
+++ b/components/polylith/repo/repo.py
@@ -13,7 +13,6 @@ bases_dir = "bases"
 components_dir = "components"
 projects_dir = "projects"
 development_dir = "development"
-report_dir = f"{development_dir}/poly"
 
 
 def load_content(fullpath: Path) -> tomlkit.TOMLDocument:

--- a/components/polylith/test/report.py
+++ b/components/polylith/test/report.py
@@ -15,7 +15,11 @@ def print_report_summary(
     number_of_components = len(components)
     number_of_bases = len(bases)
 
-    console.print(Padding("[data]Projects and bricks affected by changes in tests[/]", (1, 0, 0, 0)))
+    console.print(
+        Padding(
+            "[data]Projects and bricks affected by changes in tests[/]", (1, 0, 0, 0)
+        )
+    )
     console.print(Padding(f"[data]Test diff based on {tag}[/]", (0, 0, 1, 0)))
 
     console.print(f"[proj]Affected projects[/]: [data]{number_of_projects}[/]")
@@ -59,15 +63,10 @@ def print_detected_changes_affecting_bricks(
 def print_test_report(
     projects_data: List[dict], bases: Set[str], components: Set[str], options: dict
 ) -> None:
-    short = options.get("short", False)
-
     b = sorted(list(bases))
     c = sorted(list(components))
 
     if not b and not c:
         return
 
-    if short:
-        info.print_compressed_view_for_bricks_in_projects(projects_data, b, c)
-    else:
-        info.print_bricks_in_projects(projects_data, b, c)
+    info.print_bricks_in_projects(projects_data, b, c, options)

--- a/projects/pdm_polylith_bricks/pyproject.toml
+++ b/projects/pdm_polylith_bricks/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdm-polylith-bricks"
-version = "1.3.2"
+version = "1.3.3"
 description = "a PDM build hook for Polylith"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/pdm_polylith_workspace/pyproject.toml
+++ b/projects/pdm_polylith_workspace/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdm-polylith-workspace"
-version = "1.3.2"
+version = "1.3.3"
 description = "a PDM build hook for a Polylith workspace"
 homepage = "https://davidvujic.github.io/python-polylith-docs/"
 repository = "https://github.com/davidvujic/python-polylith"

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.41.0"
+version = "1.42.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -25,6 +25,7 @@ packages = [
     { include = "polylith/info", from = "../../components" },
     { include = "polylith/interface", from = "../../components" },
     { include = "polylith/libs", from = "../../components" },
+    { include = "polylith/output", from = "../../components" },
     { include = "polylith/poetry", from = "../../components" },
     { include = "polylith/project", from = "../../components" },
     { include = "polylith/readme", from = "../../components" },

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.34.0"
+version = "1.35.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -26,6 +26,7 @@ packages = [
     { include = "polylith/info", from = "../../components" },
     { include = "polylith/interface", from = "../../components" },
     { include = "polylith/libs", from = "../../components" },
+    { include = "polylith/output", from = "../../components" },
     { include = "polylith/parsing", from = "../../components" },
     { include = "polylith/project", from = "../../components" },
     { include = "polylith/readme", from = "../../components" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ packages = [
     { include = "polylith/info", from = "components" },
     { include = "polylith/interface", from = "components" },
     { include = "polylith/libs", from = "components" },
+    { include = "polylith/output", from = "components" },
     { include = "polylith/parsing", from = "components" },
     { include = "polylith/pdm", from = "components" },
     { include = "polylith/poetry", from = "components" },

--- a/test/components/polylith/output/test_core.py
+++ b/test/components/polylith/output/test_core.py
@@ -4,7 +4,7 @@ from polylith.output import core
 def test_adjust_output_return_string_without_emojis():
     data = "checking ✔ left 👈 or 👉 right"
 
-    expected = "checking X left < or > right"
+    expected = "checking X left <- or -> right"
 
     res = core.adjust(data)
 

--- a/test/components/polylith/output/test_core.py
+++ b/test/components/polylith/output/test_core.py
@@ -1,0 +1,11 @@
+from polylith.output import core
+
+
+def test_adjust_output_return_string_without_emojis():
+    data = "checking ✔ left 👈 or 👉 right"
+
+    expected = "checking X left < or > right"
+
+    res = core.adjust(data)
+
+    assert res == expected


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding a `--save` option to the `poly deps`, `poly info` and `poly libs` commands. In addition to printing the output (as before) a file will be saved with the contents of the output.

The location is by default in `development/poly/<command name>.txt`, but is configurable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Saving the result from the `deps`, `info` and `libs` commands is useful during Pull Requests, when reviewing code. Besides the code diff, the changes in saved commands will give the reviewer an overview of the changes such as coupling and dependency changes.

The idea comes from the discussion #365

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Local run of commands with the new `--save` option
✅ unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
