### PR TITLE
polylith-cli command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ types-pyyaml = "^6.0.12.20241230"
 
 [tool.poetry.scripts]
 poly = "polylith.cli.core:app"
+polylith-cli = "polylith.cli.core:app"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Hi David, I use [uvx](https://docs.astral.sh/uv/guides/tools/) in my workflows, it requires the entry point be the same name as the package
