### PR TITLE
feat(poly deps): view usage of brick interfaces

### DIFF
--- a/components/polylith/commands/deps.py
+++ b/components/polylith/commands/deps.py
@@ -41,6 +41,20 @@ def used_by_as_bricks(bricks: dict, brick_deps: dict) -> dict:
     }
 
 
+def print_possible_invalid_bricks_interfaces_usage(
+    root: Path, ns: str, bricks: dict, bricks_deps: dict
+) -> None:
+    flattened_bricks = set().union(*bricks.values())
+    bricks_with_deps = {b: bricks_deps[b] for b in flattened_bricks if b in bricks_deps}
+
+    for brick, brick_deps in bricks_with_deps.items():
+        used_bricks = used_by_as_bricks(bricks, brick_deps)
+
+        interface.report.print_brick_interface_invalid_usage(
+            root, ns, brick, used_bricks
+        )
+
+
 def run(root: Path, ns: str, options: dict):
     directory = options.get("directory")
     brick = options.get("brick")
@@ -84,4 +98,8 @@ def run(root: Path, ns: str, options: dict):
         return
 
     deps.print_deps(bricks, imports, options)
+
+    if show_interface:
+        print_possible_invalid_bricks_interfaces_usage(root, ns, bricks, bricks_deps)
+
     deps.print_bricks_with_circular_deps(circular_bricks, bricks)

--- a/components/polylith/deps/report.py
+++ b/components/polylith/deps/report.py
@@ -145,7 +145,9 @@ def print_brick_deps(brick: str, bricks: dict, brick_deps: dict, options: dict):
         output.save(table, options, f"deps_{brick}")
 
 
-def print_brick_with_circular_deps(brick: str, deps: Set[str], bricks: dict) -> None:
+def print_brick_with_circular_deps(
+    brick: str, deps: Set[str], bricks: dict, padding: Union[tuple, None] = None
+) -> None:
     bases = bricks["bases"]
 
     console = Console(theme=theme.poly_theme)
@@ -158,9 +160,13 @@ def print_brick_with_circular_deps(brick: str, deps: Set[str], bricks: dict) -> 
     prefix = ":information:"
     message = f"[{tag}]{brick}[/] [data]is used by[/] {others} [data]and also uses[/] {others}[data].[/]"
 
-    console.print(Padding(f"{prefix} {message}", (0, 0, 0, 1)), overflow="ellipsis")
+    pad = padding or (1, 0, 0, 1)
+    console.print(Padding(f"{prefix} {message}", pad), overflow="ellipsis")
 
 
 def print_bricks_with_circular_deps(circular_bricks: dict, bricks: dict) -> None:
+    console = Console(theme=theme.poly_theme)
+    console.print()
+
     for brick, deps in circular_bricks.items():
-        print_brick_with_circular_deps(brick, deps, bricks)
+        print_brick_with_circular_deps(brick, deps, bricks, (0, 0, 0, 1))

--- a/components/polylith/interface/report.py
+++ b/components/polylith/interface/report.py
@@ -4,6 +4,7 @@ from polylith.interface.collect import get_brick_interface
 from polylith.interface.usage import check_brick_interface_usage, unified_usages
 from polylith.reporting import theme
 from rich.console import Console
+from rich.padding import Padding
 from rich.table import Table
 
 
@@ -26,7 +27,7 @@ def print_brick_interface(root: Path, ns: str, brick: str, bricks: dict) -> None
         *_ns, exposes = str.split(endpoint, ".")
         table.add_row(f"[data]{exposes}[/]")
 
-    console.print(table, overflow="ellipsis")
+    console.print(Padding(table, (0, 0, 1, 0)), overflow="ellipsis")
 
 
 def print_brick_interface_invalid_usage(
@@ -45,7 +46,6 @@ def print_brick_interface_invalid_usage(
 
     console = Console(theme=theme.poly_theme)
 
-    table = Table(box=None)
     tag = "base" if brick in bricks["bases"] else "comp"
 
     for using_brick, usages in invalid_usage.items():
@@ -58,6 +58,4 @@ def print_brick_interface_invalid_usage(
 
             message = f":information: {prefix}: {middle}."
 
-            table.add_row(f"{message}")
-
-    console.print(table, overflow="ellipsis")
+            console.print(Padding(f"{message}", (0, 0, 0, 1)), overflow="ellipsis")

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.50.0"
+version = "1.51.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.44.0"
+version = "1.45.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding visualization for brick interface usage. The new view will report if the defined brick interfaces are bypassed.

Previouly, it has been possible to view the usage of an individual brick (announced [here](https://github.com/DavidVujic/python-polylith/discussions/424)), but with the changes in this Pull Request, bypassed interface usage is visualized for all bricks.

Usage:
```shell
poly deps --interface
```

This will append a table of any usages that isn't going through the defined brick interface (i.e. the `__init__.py` of the brick).

Example output:
```shell
ℹ Found in the_other_brick: hello_world is not part of the public interface of my_brick_x. 
ℹ Found in another_brick: greeting is not part of the public interface of my_brick_y. 
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This feature will make it possible to inspect how the bricks are used across the Polylith workspace. With the notifications about usage outside of the interface boundaries, you will be able to identify any unexpected usages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Local run of the `poly deps` command

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
