### PR TITLE
Fix poly sync for PEP 621 build backends that isn't hatchling or pdm

### DIFF
--- a/components/polylith/sync/update.py
+++ b/components/polylith/sync/update.py
@@ -46,15 +46,7 @@ def generate_updated_pep_621_project(data: TOMLDocument, bricks_to_add: dict) ->
     return tomlkit.dumps(copy)
 
 
-def generate_updated_pdm_project(data: TOMLDocument, packages: List[dict]) -> str:
-    bricks_to_add: dict = reduce(to_key_value_include, packages, {})
-
-    return generate_updated_pep_621_project(data, bricks_to_add)
-
-
-def generate_updated_hatch_project(data: TOMLDocument, packages: List[dict]) -> str:
-    bricks_to_add: dict = reduce(to_key_value_include, packages, {})
-
+def generate_updated_hatch_project(data: TOMLDocument, bricks_to_add: dict) -> str:
     has_polylith = data.get("tool", {}).get("polylith", {}).get("bricks")
     has_hatch = (
         data.get("tool", {}).get("hatch", {}).get("build", {}).get("force-include")
@@ -91,11 +83,13 @@ def generate_updated_project(
     if repo.is_poetry(data):
         return generate_updated_poetry_project(data, packages)
 
-    if repo.is_hatch(data):
-        return generate_updated_hatch_project(data, packages)
+    bricks_to_add: dict = reduce(to_key_value_include, packages, {})
 
-    if repo.is_pdm(data):
-        return generate_updated_pdm_project(data, packages)
+    if repo.is_hatch(data):
+        return generate_updated_hatch_project(data, bricks_to_add)
+
+    if repo.is_pep_621_ready(data):
+        return generate_updated_pep_621_project(data, bricks_to_add)
 
     return None
 

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.51.0"
+version = "1.51.1"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.45.0"
+version = "1.45.1"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixing an issue with the `poly sync` command, when using a build backend that isn't Hatchling, PDM or Poetry.

The way the command identified how to sync bricks didn't take other PEP 621-ready pyproject.toml files into account (such as when using the _uv_ build backend).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To make it possible to sync bricks in development and in projects using `poly sync`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Local testing of the poly sync command.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
