### PR TITLE
feat(poly create project): quiet option does not trigger interactive mode

### DIFF
--- a/bases/polylith/cli/create.py
+++ b/bases/polylith/cli/create.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from polylith import interactive, project
 from polylith.bricks import base, component
+from polylith.cli import options
 from polylith.commands.create import create
 from polylith.workspace.create import create_workspace
 from typer import Exit, Option, Typer
@@ -57,11 +58,13 @@ def _create_project(root: Path, options: dict):
 def project_command(
     name: Annotated[str, Option(help="Name of the project.")],
     description: Annotated[str, Option(help="Description of the project.")] = "",
+    quiet: Annotated[bool, options.quiet] = False,
 ):
     """Creates a Polylith project."""
     create(name, description, _create_project)
 
-    interactive.project.run(name)
+    if not quiet:
+        interactive.project.run(name)
 
 
 @app.command("workspace")

--- a/components/polylith/poetry/commands/create_project.py
+++ b/components/polylith/poetry/commands/create_project.py
@@ -34,9 +34,11 @@ class CreateProjectCommand(Command):
     def handle(self) -> int:
         name = self.option("name")
         description = self.option("description")
+        quiet = self.option("quiet")
 
         create(name, description, create_project)
 
-        interactive.project.run(name)
+        if not quiet:
+            interactive.project.run(name)
 
         return 0

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.51.3"
+version = "1.52.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.45.3"
+version = "1.46.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding support for a `--quiet` option for the `poly create project` command. This option will not trigger any _interactive_ mode (i.e. not asking to add a _base_ if available).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This option is useful for agents when runing the `poly` tool.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
