### PR TITLE
fix: bump version of the dependent rich library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1745,4 +1745,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8.1"
-content-hash = "b16631cbcbe0165ec9ed0a7c7babd042da287fa538e9f9ab2a70be9846d9439c"
+content-hash = "6a0af6a3359611ead9143b0a3ccb973f9aa9e4bde79ebcaea1d0220d7fb3daca"

--- a/projects/poetry_polylith_plugin/poetry.lock
+++ b/projects/poetry_polylith_plugin/poetry.lock
@@ -1403,4 +1403,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8"
-content-hash = "2e5471c4768919b84e222b39e47a469ad82f3fa558a431f74f1034a6e4a6ab99"
+content-hash = "2cd7ccc44e2be7ffbc71701644cdf579b69e15a23589d7f56dc0f2ad2b1d52d2"

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -46,7 +46,7 @@ poetry-polylith-plugin = "polylith.poetry_plugin:PolylithPlugin"
 python = "^3.8"
 poetry = "*"
 tomlkit = "0.*"
-rich = ">=13,<15"
+rich = "*"
 cleo = "^2.1.0"
 pyyaml = "*"
 

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.52.0"
+version = "1.52.1"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/poetry.lock
+++ b/projects/polylith_cli/poetry.lock
@@ -219,4 +219,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8"
-content-hash = "11e2c7d8e1f0102a49415d2ebdc0e9ce3f51f0cef18e1e38ddd0ad5a0297655f"
+content-hash = "193944e9d2bef4ff90e20fbcc89d16efca9241e73e49324552a9c0b44246a6cd"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.48.1"
+version = "1.48.2"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -45,7 +45,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.8"
 tomlkit = "0.*"
-rich = ">=13,<15"
+rich = "*"
 typer = "0.*"
 pyyaml = "*"
 typing_extensions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ packages = [
 python = "^3.8.1"
 poetry = "*"
 tomlkit = "0.*"
-rich = ">=13,<15"
+rich = "*"
 cleo = "^2.1.0"
 hatchling = "^1.21.0"
 typer = "0.*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Setting the version to a wildcard for the `rich` library, that is used in the poly tool.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To avoid any conflicts with usage of the `rich` library by the users:
a Polylith monorepo is using the poly tool, and also have a direct dependency to the rich library, but with a later version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
