### PR TITLE
Fix brick usage via interface

### DIFF
--- a/bases/polylith/cli/create.py
+++ b/bases/polylith/cli/create.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from polylith import interactive, project
-from polylith.bricks import base, component
+from polylith.bricks import create_base, create_component
 from polylith.cli import options
 from polylith.commands.create import create
 from polylith.workspace.create import create_workspace
@@ -26,7 +26,7 @@ def base_command(
     description: Annotated[str, Option(help="Description of the base.")] = "",
 ):
     """Creates a Polylith base."""
-    _try_create(name, description, base.create_base)
+    _try_create(name, description, create_base)
 
 
 @app.command("component")
@@ -35,7 +35,7 @@ def component_command(
     description: Annotated[str, Option(help="Description of the component.")] = "",
 ):
     """Creates a Polylith component."""
-    _try_create(name, description, component.create_component)
+    _try_create(name, description, create_component)
 
 
 def _create_project(root: Path, options: dict):

--- a/components/polylith/bricks/__init__.py
+++ b/components/polylith/bricks/__init__.py
@@ -1,9 +1,7 @@
-from polylith.bricks.base import create_base, get_bases_data
-from polylith.bricks.component import create_component, get_components_data
+from polylith.bricks.base import create_base
+from polylith.bricks.component import create_component
 
 __all__ = [
     "create_base",
     "create_component",
-    "get_bases_data",
-    "get_components_data",
 ]

--- a/components/polylith/bricks/base.py
+++ b/components/polylith/bricks/base.py
@@ -1,7 +1,5 @@
 from pathlib import Path
-from typing import List
 
-from polylith.bricks import component
 from polylith.bricks.brick import create_brick
 from polylith.repo import bases_dir
 from polylith.test import create_test
@@ -13,7 +11,3 @@ def create_base(path: Path, options: dict) -> None:
 
     create_brick(path, base_options)
     create_test(path, base_options)
-
-
-def get_bases_data(path: Path, ns: str) -> List[dict]:
-    return component.get_components_data(path, ns, bases_dir)

--- a/components/polylith/bricks/component.py
+++ b/components/polylith/bricks/component.py
@@ -1,7 +1,5 @@
 from pathlib import Path
-from typing import List
 
-from polylith import configuration
 from polylith.bricks.brick import create_brick
 from polylith.repo import components_dir
 from polylith.test import create_test
@@ -13,27 +11,3 @@ def create_component(path: Path, options: dict) -> None:
 
     create_brick(path, component_options)
     create_test(path, component_options)
-
-
-def is_brick_dir(p: Path) -> bool:
-    return p.is_dir() and p.name not in {"__pycache__", ".venv", ".mypy_cache"}
-
-
-def get_component_dirs(root: Path, top_dir, ns) -> list:
-    theme = configuration.get_theme_from_config(root)
-    dirs = top_dir if theme == "tdd" else f"{top_dir}/{ns}"
-
-    component_dir = root / dirs
-
-    if not component_dir.exists():
-        return []
-
-    return [f for f in component_dir.iterdir() if is_brick_dir(f)]
-
-
-def get_components_data(
-    root: Path, ns: str, top_dir: str = components_dir
-) -> List[dict]:
-    dirs = get_component_dirs(root, top_dir, ns)
-
-    return [{"name": d.name} for d in dirs]

--- a/components/polylith/check/report.py
+++ b/components/polylith/check/report.py
@@ -78,8 +78,8 @@ def extract_collected_imports(
     ns: str, imports_in_bases: dict, imports_in_components: dict
 ) -> dict:
     brick_imports = {
-        "bases": imports.grouping.extract_brick_imports(imports_in_bases, ns),
-        "components": imports.grouping.extract_brick_imports(imports_in_components, ns),
+        "bases": imports.extract_brick_imports(imports_in_bases, ns),
+        "components": imports.extract_brick_imports(imports_in_components, ns),
     }
 
     third_party_imports = {

--- a/components/polylith/commands/deps.py
+++ b/components/polylith/commands/deps.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import List, Set
 
 from polylith import deps, info, interface
-from polylith.bricks import get_bases_data, get_components_data
+from polylith.dirs import get_bases_data, get_components_data
 
 
 def get_imports(root: Path, ns: str, bricks: dict) -> dict:

--- a/components/polylith/commands/deps.py
+++ b/components/polylith/commands/deps.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 from typing import List, Set
 
-from polylith import bricks, deps, info, interface
+from polylith import deps, info, interface
+from polylith.bricks import get_bases_data, get_components_data
 
 
 def get_imports(root: Path, ns: str, bricks: dict) -> dict:
@@ -20,14 +21,14 @@ def get_bases(root: Path, ns: str, project_data: dict) -> Set[str]:
     if project_data:
         return set(project_data.get("bases", []))
 
-    return pick_name(bricks.get_bases_data(root, ns))
+    return pick_name(get_bases_data(root, ns))
 
 
 def get_components(root: Path, ns: str, project_data: dict) -> Set[str]:
     if project_data:
         return set(project_data.get("components", []))
 
-    return pick_name(bricks.get_components_data(root, ns))
+    return pick_name(get_components_data(root, ns))
 
 
 def used_by_as_bricks(bricks: dict, brick_deps: dict) -> dict:

--- a/components/polylith/commands/diff.py
+++ b/components/polylith/commands/diff.py
@@ -28,7 +28,7 @@ def flatten_dependent_bricks(
     changed_bricks: Set[str], bases: Set[str], components: Set[str], import_data: dict
 ) -> Set[str]:
     matrix = [
-        deps.core.sorted_used_by(brick, bases, components, import_data)
+        deps.sorted_used_by(brick, bases, components, import_data)
         for brick in changed_bricks
     ]
 

--- a/components/polylith/commands/test.py
+++ b/components/polylith/commands/test.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import List, Set, Tuple, Union
 
-from polylith import bricks, configuration, diff, info, test
+from polylith import configuration, diff, dirs, info, test
 
 
 def get_imported_bricks_in_tests(
@@ -22,8 +22,8 @@ def get_affected_bricks(
 ) -> Tuple[Set[str], Set[str]]:
     found = get_imported_bricks_in_tests(root, ns, tag_name, theme)
 
-    bases = extract_brick_names(bricks.get_bases_data(root, ns), found)
-    components = extract_brick_names(bricks.get_components_data(root, ns), found)
+    bases = extract_brick_names(dirs.get_bases_data(root, ns), found)
+    components = extract_brick_names(dirs.get_components_data(root, ns), found)
 
     return bases, components
 

--- a/components/polylith/deps/__init__.py
+++ b/components/polylith/deps/__init__.py
@@ -2,6 +2,7 @@ from polylith.deps.core import (
     calculate_brick_deps,
     find_bricks_with_circular_dependencies,
     get_brick_imports,
+    sorted_used_by,
 )
 from polylith.deps.report import (
     print_brick_deps,
@@ -13,7 +14,8 @@ from polylith.deps.report import (
 __all__ = [
     "calculate_brick_deps",
     "find_bricks_with_circular_dependencies",
-    "get_brick_imports",
+    "get_brick_imports"
+    "sorted_used_by",
     "print_brick_deps",
     "print_brick_with_circular_deps",
     "print_bricks_with_circular_deps",

--- a/components/polylith/deps/__init__.py
+++ b/components/polylith/deps/__init__.py
@@ -14,7 +14,7 @@ from polylith.deps.report import (
 __all__ = [
     "calculate_brick_deps",
     "find_bricks_with_circular_dependencies",
-    "get_brick_imports"
+    "get_brick_imports",
     "sorted_used_by",
     "print_brick_deps",
     "print_brick_with_circular_deps",

--- a/components/polylith/dirs/__init__.py
+++ b/components/polylith/dirs/__init__.py
@@ -1,3 +1,3 @@
-from polylith.dirs.dirs import create_dir
+from polylith.dirs.dirs import create_dir, get_bases_data, get_components_data
 
-__all__ = ["create_dir"]
+__all__ = ["create_dir", "get_bases_data", "get_components_data"]

--- a/components/polylith/dirs/dirs.py
+++ b/components/polylith/dirs/dirs.py
@@ -1,6 +1,9 @@
 from pathlib import Path
+from typing import List
 
+from polylith import configuration
 from polylith.files import create_file
+from polylith.repo import bases_dir, components_dir
 
 keep_file_name = ".keep"
 
@@ -13,3 +16,31 @@ def create_dir(path: Path, dir_name: str, keep=False) -> Path:
         create_file(d, keep_file_name)
 
     return d
+
+
+def is_brick_dir(p: Path) -> bool:
+    return p.is_dir() and p.name not in {"__pycache__", ".venv", ".mypy_cache"}
+
+
+def get_component_dirs(root: Path, top_dir, ns) -> list:
+    theme = configuration.get_theme_from_config(root)
+    dirs = top_dir if theme == "tdd" else f"{top_dir}/{ns}"
+
+    component_dir = root / dirs
+
+    if not component_dir.exists():
+        return []
+
+    return [f for f in component_dir.iterdir() if is_brick_dir(f)]
+
+
+def get_components_data(
+    root: Path, ns: str, top_dir: str = components_dir
+) -> List[dict]:
+    dirs = get_component_dirs(root, top_dir, ns)
+
+    return [{"name": d.name} for d in dirs]
+
+
+def get_bases_data(path: Path, ns: str) -> List[dict]:
+    return get_components_data(path, ns, bases_dir)

--- a/components/polylith/imports/__init__.py
+++ b/components/polylith/imports/__init__.py
@@ -9,12 +9,18 @@ from polylith.imports.parser import (
     list_imports,
     parse_module,
 )
-from polylith.imports.usages import SYMBOLS, extract_api, fetch_brick_import_usages
+from polylith.imports.usages import (
+    SYMBOLS,
+    extract_api,
+    extract_api_part,
+    fetch_brick_import_usages,
+)
 
 __all__ = [
     "extract_brick_imports",
     "extract_brick_imports_with_namespaces",
     "extract_api",
+    "extract_api_part",
     "extract_top_ns",
     "fetch_all_imports",
     "fetch_brick_import_usages",

--- a/components/polylith/info/collect.py
+++ b/components/polylith/info/collect.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import List, Set
 
-from polylith.bricks import get_bases_data, get_components_data
+from polylith.dirs import get_bases_data, get_components_data
 
 from polylith.info.report import is_project
 from polylith.project import get_packages_for_projects, parse_package_paths

--- a/components/polylith/info/collect.py
+++ b/components/polylith/info/collect.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 from typing import List, Set
 
-from polylith.bricks import base, component
+from polylith.bricks import get_bases_data, get_components_data
+
 from polylith.info.report import is_project
 from polylith.project import get_packages_for_projects, parse_package_paths
 
@@ -26,11 +27,11 @@ def get_project_bricks(project_packages: List[dict], components, bases, namespac
 
 
 def get_components(root: Path, namespace: str) -> List[str]:
-    return [c["name"] for c in component.get_components_data(root, namespace)]
+    return [c["name"] for c in get_components_data(root, namespace)]
 
 
 def get_bases(root: Path, namespace: str) -> List[str]:
-    return [b["name"] for b in base.get_bases_data(root, namespace)]
+    return [b["name"] for b in get_bases_data(root, namespace)]
 
 
 def get_bricks_in_projects(

--- a/components/polylith/interface/usage.py
+++ b/components/polylith/interface/usage.py
@@ -24,7 +24,7 @@ def unified_usages(usages: dict) -> Set[str]:
 
 
 def to_imported_api(brick_imports: Set[str]) -> Set[str]:
-    return {imports.usages.extract_api_part(b) for b in brick_imports}
+    return {imports.extract_api_part(b) for b in brick_imports}
 
 
 def equals_or_starts_with(brick_import: str, brick: str, ns: str) -> bool:

--- a/components/polylith/pdm/__init__.py
+++ b/components/polylith/pdm/__init__.py
@@ -1,0 +1,3 @@
+from polylith.pdm import hooks
+
+__all__ = ["hooks"]

--- a/components/polylith/poetry/commands/create_base.py
+++ b/components/polylith/poetry/commands/create_base.py
@@ -1,6 +1,6 @@
 from cleo.helpers import option
 from poetry.console.commands.command import Command
-from polylith.bricks import base
+from polylith.bricks import create_base
 from polylith.poetry.commands.create_brick import try_create
 
 
@@ -20,4 +20,4 @@ class CreateBaseCommand(Command):
     ]
 
     def handle(self) -> int:
-        return try_create(self, base.create_base)
+        return try_create(self, create_base)

--- a/components/polylith/poetry/commands/create_component.py
+++ b/components/polylith/poetry/commands/create_component.py
@@ -1,6 +1,6 @@
 from cleo.helpers import option
 from poetry.console.commands.command import Command
-from polylith.bricks import component
+from polylith.bricks import create_component
 from polylith.poetry.commands.create_brick import try_create
 
 
@@ -20,4 +20,4 @@ class CreateComponentCommand(Command):
     ]
 
     def handle(self) -> int:
-        return try_create(self, component.create_component)
+        return try_create(self, create_component)

--- a/development/david.py
+++ b/development/david.py
@@ -46,4 +46,4 @@ changed_projects = diff.collect.get_changed_projects(root, changed_files)
 
 projects_data = info.get_bricks_in_projects(root, changed_components, changed_bases, ns)
 
-bases_data = bricks.base.get_bases_data(root, ns)
+bases_data = dirs.get_bases_data(root, ns)

--- a/projects/pdm_polylith_bricks/pyproject.toml
+++ b/projects/pdm_polylith_bricks/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdm-polylith-bricks"
-version = "1.3.9"
+version = "1.3.10"
 description = "a PDM build hook for Polylith"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/pdm_polylith_workspace/pyproject.toml
+++ b/projects/pdm_polylith_workspace/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdm-polylith-workspace"
-version = "1.3.9"
+version = "1.3.10"
 description = "a PDM build hook for a Polylith workspace"
 homepage = "https://davidvujic.github.io/python-polylith-docs/"
 repository = "https://github.com/davidvujic/python-polylith"

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.52.1"
+version = "1.52.2"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.48.2"
+version = "1.48.3"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/bricks/test_base.py
+++ b/test/components/polylith/bricks/test_base.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from polylith.bricks.base import create_base, get_bases_data
+from polylith.bricks.base import create_base
+from polylith.dirs import get_bases_data
 
 
 def test_create_base(handle_workspace_files, tmp_path: Path):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from polylith.bricks.base import create_base
+from polylith.bricks import create_base
 
 source_file = """
 [tool.polylith]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removing brick interface bypassing, and circular references that was reported by the `poly deps --interface` command:

```shell
 ℹ Found in check: grouping is not part of the public interface of imports.                                                                 
 ℹ Found in interface: usages is not part of the public interface of imports.                                                               
 ℹ Found in commands: core is not part of the public interface of deps.                                                                     
 ℹ Found in pdm_workspace_hooks: hooks is not part of the public interface of pdm.                                                          
 ℹ Found in pdm_project_hooks: hooks is not part of the public interface of pdm.                                                            
 ℹ Found in poetry: component is not part of the public interface of bricks.                                                                
 ℹ Found in poetry: base is not part of the public interface of bricks.                                                                     
 ℹ Found in commands: values is not part of the public interface of bricks.                                                                 
 ℹ Found in cli: component is not part of the public interface of bricks.                                                                   
 ℹ Found in cli: base is not part of the public interface of bricks.                                                                        
 ℹ Found in info: component is not part of the public interface of bricks.                                                                  
 ℹ Found in info: base is not part of the public interface of bricks.                                                                       

 ℹ bricks is used by info and also uses info.                                                                                               
 ℹ info is used by bricks and also uses bricks.         
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This repo should align with what is recommended for bricks in the Polylith architecture, communicating via explicit interfaces.

Also: circular brick dependencies can cause future issues and should be fixed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ run the poly commands

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).

Before:

<img width="960" height="708" alt="poly-deps" src="https://github.com/user-attachments/assets/47e3724e-5834-4171-8952-8a7389f56766" />


After:

<img width="960" height="708" alt="poly-deps-after" src="https://github.com/user-attachments/assets/9d3cd230-ce9e-432d-8c88-a0282612dbac" />

