### PR TITLE
feat(poly sync): sort the bricks to add by brick type and alphabetically

### DIFF
--- a/components/polylith/sync/update.py
+++ b/components/polylith/sync/update.py
@@ -1,3 +1,5 @@
+import itertools
+import operator
 from functools import reduce
 from pathlib import Path
 from typing import List, Union
@@ -28,6 +30,10 @@ def to_key_value_include(acc: dict, package: dict) -> dict:
     return {**acc, **{include: brick}}
 
 
+def sort_bricks(bricks: dict) -> List[tuple]:
+    return sorted(bricks.items(), key=lambda i: i[0])
+
+
 def generate_updated_pep_621_project(data: TOMLDocument, bricks_to_add: dict) -> str:
     copy = copy_toml_data(data)
 
@@ -40,7 +46,7 @@ def generate_updated_pep_621_project(data: TOMLDocument, bricks_to_add: dict) ->
     if not copy["tool"]["polylith"].get("bricks"):
         copy["tool"]["polylith"]["bricks"] = {}
 
-    for k, v in bricks_to_add.items():
+    for k, v in sort_bricks(bricks_to_add):
         copy["tool"]["polylith"]["bricks"][k] = v
 
     return tomlkit.dumps(copy)
@@ -55,12 +61,30 @@ def generate_updated_hatch_project(data: TOMLDocument, bricks_to_add: dict) -> s
     if not has_polylith and has_hatch:
         copy = copy_toml_data(data)
 
-        for k, v in bricks_to_add.items():
+        for k, v in sort_bricks(bricks_to_add):
             copy["tool"]["hatch"]["build"]["force-include"][k] = v
 
         return tomlkit.dumps(copy)
 
     return generate_updated_pep_621_project(data, bricks_to_add)
+
+
+def sort_fn_by_from(data: dict) -> str:
+    return data["from"]
+
+
+def sort_fn_by_include(data: dict) -> str:
+    return data["include"]
+
+
+def to_sorted_packages(packages: List[dict]) -> List[dict]:
+    sorted_by_brick_type = sorted(packages, key=sort_fn_by_from)
+    grouped = itertools.groupby(sorted_by_brick_type, key=sort_fn_by_from)
+
+    groups = [list(g) for _k, g in grouped]
+    flattened: List[dict] = reduce(operator.iadd, groups, [])
+
+    return sorted(flattened, key=sort_fn_by_include)
 
 
 def generate_updated_poetry_project(data: TOMLDocument, packages: List[dict]) -> str:
@@ -69,7 +93,7 @@ def generate_updated_poetry_project(data: TOMLDocument, packages: List[dict]) ->
     if copy["tool"]["poetry"].get("packages") is None:
         copy["tool"]["poetry"].add("packages", [])
 
-    for package in packages:
+    for package in to_sorted_packages(packages):
         copy["tool"]["poetry"]["packages"].append(package)
 
     copy["tool"]["poetry"]["packages"].multiline(True)

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.52.2"
+version = "1.53.0"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.48.3"
+version = "1.49.0"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/sync/test_update.py
+++ b/test/components/polylith/sync/test_update.py
@@ -1,7 +1,14 @@
 from pathlib import Path
+from typing import Union
 
 import tomlkit
 from polylith.sync import update
+
+
+def parse(data: Union[str, None]) -> dict:
+    parsed = tomlkit.parse(data) if data else {}
+
+    return parsed or {}
 
 
 def test_brick_to_pyproject_package():
@@ -70,10 +77,20 @@ expected_hatch_packages = {
     "components/hello/third": "hello/third",
 }
 
+unsorted_packages = [
+    {"include": "hello/c", "from": "components"},
+    {"include": "hello/a", "from": "bases"},
+    {"include": "hello/b", "from": "components"},
+]
 
-def test_generate_updated_poetry_project():
-    data = tomlkit.parse(
-        """\
+expected_sorted_pep621_bricks = {
+    "bases/hello/first": "hello/first",
+    "bases/hello/a": "hello/a",
+    "components/hello/b": "hello/b",
+    "components/hello/c": "hello/c",
+}
+
+poetry_project_data = """\
 [tool.poetry]
 packages = [{include = "hello/first", from = "bases"}]
 
@@ -81,64 +98,105 @@ packages = [{include = "hello/first", from = "bases"}]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 """
-    )
+
+
+hatchling_build_system = """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+"""
+
+hatchling_project_data = """\
+{build_system}
+
+[tool.polylith.bricks]
+"bases/hello/first" = "hello/first"
+""".format(
+    build_system=hatchling_build_system
+)
+
+hatch_specific_project_data = """\
+{build_system}
+
+[tool.hatch.build.force-include]
+"bases/hello/first" = "hello/first"
+""".format(
+    build_system=hatchling_build_system
+)
+
+
+def test_generate_updated_poetry_project():
+    data = tomlkit.parse(poetry_project_data)
 
     updated = update.generate_updated_project(data, packages[1:])
 
-    res = tomlkit.parse(updated)["tool"]["poetry"]["packages"]
+    res = parse(updated)["tool"]["poetry"]["packages"]
 
     assert res == packages
 
 
-def test_generate_updated_hatch_project_with_existing_polylith_sections():
-    data = tomlkit.parse(
-        """\
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+def test_generate_updated_poetry_project_with_the_bricks_to_update_sorted():
+    data = tomlkit.parse(poetry_project_data)
 
-[tool.polylith.bricks]
-"bases/hello/first" = "hello/first"
-"""
-    )
+    expected = [
+        {"include": "hello/first", "from": "bases"},
+        {"include": "hello/a", "from": "bases"},
+        {"include": "hello/b", "from": "components"},
+        {"include": "hello/c", "from": "components"},
+    ]
+
+    updated = update.generate_updated_project(data, unsorted_packages)
+
+    res = parse(updated)["tool"]["poetry"]["packages"]
+
+    assert res == expected
+
+
+def test_generate_updated_hatch_project_with_existing_polylith_sections():
+    data = tomlkit.parse(hatchling_project_data)
 
     updated = update.generate_updated_project(data, packages[1:])
 
-    res = tomlkit.parse(updated)["tool"]["polylith"]["bricks"]
+    res = parse(updated)["tool"]["polylith"]["bricks"]
 
     assert res == expected_hatch_packages
 
 
+def test_generate_updated_pep621_project_with_the_bricks_to_update_sorted():
+    data = tomlkit.parse(hatchling_project_data)
+
+    updated = update.generate_updated_project(data, unsorted_packages)
+
+    res = parse(updated)["tool"]["polylith"]["bricks"]
+
+    assert list(res.keys()) == list(expected_sorted_pep621_bricks.keys())
+
+
 def test_generate_updated_hatch_project_with_missing_brick_config():
-    data = tomlkit.parse(
-        """\
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-"""
-    )
+    data = tomlkit.parse(hatchling_build_system)
 
     updated = update.generate_updated_project(data, packages)
 
-    res = tomlkit.parse(updated)["tool"]["polylith"]["bricks"]
+    res = parse(updated)["tool"]["polylith"]["bricks"]
 
     assert res == expected_hatch_packages
 
 
 def test_generate_updated_hatch_project_with_existing_force_include():
-    data = tomlkit.parse(
-        """\
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build.force-include]
-"bases/hello/first" = "hello/first"
-"""
-    )
+    data = tomlkit.parse(hatch_specific_project_data)
 
     updated = update.generate_updated_project(data, packages[1:])
 
-    res = tomlkit.parse(updated)["tool"]["hatch"]["build"]["force-include"]
+    res = parse(updated)["tool"]["hatch"]["build"]["force-include"]
 
     assert res == expected_hatch_packages
+
+
+def test_generate_updated_hatch_project_force_include_with_sorted_bricks():
+    data = tomlkit.parse(hatch_specific_project_data)
+
+    updated = update.generate_updated_project(data, unsorted_packages)
+
+    res = parse(updated)["tool"]["hatch"]["build"]["force-include"]
+
+    assert list(res.keys()) == list(expected_sorted_pep621_bricks.keys())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When running `poly sync`: sorting the bricks that are missing in the `pyproject.toml` files.
Sorting by brick type, and then alphabetically
first bases, then components.

Comment: the use case for the sync command is mostly to handle missing components, but in cases where there are multible bases, the sorting will handle that too.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To improve the developer experience, making the added bricks nicely sorted, for teams that only adds a base to a project, and then relies on the `poly sync` command to add all the needed components.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ added unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
