### PR TITLE
fix(poly sync): sort by type and then alphabetically for Poetry projects

### DIFF
--- a/components/polylith/sync/update.py
+++ b/components/polylith/sync/update.py
@@ -81,10 +81,9 @@ def to_sorted_packages(packages: List[dict]) -> List[dict]:
     sorted_by_brick_type = sorted(packages, key=sort_fn_by_from)
     grouped = itertools.groupby(sorted_by_brick_type, key=sort_fn_by_from)
 
-    groups = [list(g) for _k, g in grouped]
-    flattened: List[dict] = reduce(operator.iadd, groups, [])
+    groups = [sorted(g, key=sort_fn_by_include) for _k, g in grouped]
 
-    return sorted(flattened, key=sort_fn_by_include)
+    return reduce(operator.iadd, groups, [])
 
 
 def generate_updated_poetry_project(data: TOMLDocument, packages: List[dict]) -> str:

--- a/projects/poetry_polylith_plugin/pyproject.toml
+++ b/projects/poetry_polylith_plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-polylith-plugin"
-version = "1.53.0"
+version = "1.53.1"
 description = "A Poetry plugin that adds tooling support for the Polylith Architecture"
 authors = ["David Vujic"]
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/projects/polylith_cli/pyproject.toml
+++ b/projects/polylith_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polylith-cli"
-version = "1.49.0"
+version = "1.49.1"
 description = "Python tooling support for the Polylith Architecture"
 authors = ['David Vujic']
 homepage = "https://davidvujic.github.io/python-polylith-docs/"

--- a/test/components/polylith/sync/test_update.py
+++ b/test/components/polylith/sync/test_update.py
@@ -78,16 +78,16 @@ expected_hatch_packages = {
 }
 
 unsorted_packages = [
-    {"include": "hello/c", "from": "components"},
-    {"include": "hello/a", "from": "bases"},
     {"include": "hello/b", "from": "components"},
+    {"include": "hello/x", "from": "bases"},
+    {"include": "hello/a", "from": "components"},
 ]
 
 expected_sorted_pep621_bricks = {
     "bases/hello/first": "hello/first",
-    "bases/hello/a": "hello/a",
+    "bases/hello/x": "hello/x",
+    "components/hello/a": "hello/a",
     "components/hello/b": "hello/b",
-    "components/hello/c": "hello/c",
 }
 
 poetry_project_data = """\
@@ -140,9 +140,9 @@ def test_generate_updated_poetry_project_with_the_bricks_to_update_sorted():
 
     expected = [
         {"include": "hello/first", "from": "bases"},
-        {"include": "hello/a", "from": "bases"},
+        {"include": "hello/x", "from": "bases"},
+        {"include": "hello/a", "from": "components"},
         {"include": "hello/b", "from": "components"},
-        {"include": "hello/c", "from": "components"},
     ]
 
     updated = update.generate_updated_project(data, unsorted_packages)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixing an issue with the sorting of bricks to sync for Poetry projects.

This was introduced in #457 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should sort first by brick type (i.e. bases, then components) and then alphabetically.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ refactored unit tests
✅ local run of the poly sync command

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-polylith/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-polylith/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
